### PR TITLE
Removes forced input_conformal_flag = TRUE when compiliing with conformal

### DIFF
--- a/src_main_pub/interpreta_switches.F90
+++ b/src_main_pub/interpreta_switches.F90
@@ -2154,10 +2154,6 @@ CONTAINS
   !!!    l%run_with_abrezanjas = .true. !OJO 0323 A VECES DA ERROR. PONER A FALSE SI SUCEDE
       l%run_with_abrezanjas = .false. !OJO 0323 A VECES DA ERROR. PONER A FALSE SI SUCEDE
       !!!!l%run_with_abrezanjas = .false.
-      if (.NOT.l%input_conformal_flag) then
-            l%conformal_file_input_name = char(0)
-            l%input_conformal_flag = .true.
-      end if
 #else
       l%run_with_abrezanjas = .false.
 #endif


### PR DESCRIPTION
The compilation flag CompileWithConformal was forcing the flag input_conformal_flag to be TRUE. That meant that when compiliing with conformal features the input was expected to be a conformal problem, which might not be the case