### PR TITLE
Missing EpsMuTimeScale_input_parameters in solver_t

### DIFF
--- a/src_main_pub/maloney_nostoch.F90
+++ b/src_main_pub/maloney_nostoch.F90
@@ -94,7 +94,8 @@ contains
 ! Subroutine to initialize the parameters
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 subroutine InitSGBCs(sgg,media,Ex,Ey,Ez,Hx,Hy,Hz,IDxe,IDye,IDze,IDxh,IDyh,IDzh, &
-                     layoutnumber,size,g,ThereAreSGBCs,resume,temp_SGBCcrank,temp_SGBCFreq,temp_SGBCresol,temp_SGBCDepth,temp_SGBCDispersive, &
+                     layoutnumber,size,g,ThereAreSGBCs,resume, &
+                     temp_SGBCcrank,temp_SGBCFreq,temp_SGBCresol,temp_SGBCDepth,temp_SGBCDispersive, &
                      eps00,mu00,simu_devia,stochastic)
    type(media_matrices_t), intent(in) :: media
    logical :: simu_devia,stochastic 

--- a/src_main_pub/semba_fdtd.F90
+++ b/src_main_pub/semba_fdtd.F90
@@ -408,14 +408,14 @@ contains
 #ifdef CompileWithMPI
             CALL MPI_Barrier (SUBCOMM_MPI, this%l%ierr)
             CALL conformal_ini (TRIM(this%l%conformal_file_input_name),trim(this%l%fileFDE),parser,&
-               &this%sgg, this%sggMiEx,this%sggMiEy,this%sggMiEz,this%sggMiHx,this%sggMiHy,this%sggMiHz,this%l%run_with_abrezanjas,&
+               &this%sgg, this%media%sggMiEx,this%media%sggMiEy,this%media%sggMiEz,this%media%sggMiHx,this%media%sggMiHy,this%media%sggMiHz,this%l%run_with_abrezanjas,&
                &this%fullsize,this%l%layoutnumber,this%l%mpidir, this%l%input_conformal_flag,conf_err,this%l%verbose)
 #endif
             !......................................................................
 #ifndef CompileWithMPI
             !CALL conformal_ini (TRIM(this%l%conformal_file_input_name),trim(this%l%fileFDE),sgg,fullsize,0,conf_err,this%l%verbose)
          CALL conformal_ini (TRIM(this%l%conformal_file_input_name),trim(this%l%fileFDE),parser,&
-               &this%sgg, this%sggMiEx,this%sggMiEy,this%sggMiEz,this%sggMiHx,this%sggMiHy,this%sggMiHz,&
+               &this%sgg, this%media%sggMiEx,this%media%sggMiEy,this%media%sggMiEz,this%media%sggMiHx,this%media%sggMiHy,this%media%sggMiHz,&
                &this%l%run_with_abrezanjas,this%fullsize,0,this%l%mpidir,this%l%input_conformal_flag,conf_err,this%l%verbose)
 #endif
             if(conf_err/=0)then
@@ -472,7 +472,7 @@ contains
                write(dubuf,*) '----> this%l%input_conformal_flag True and init';  call print11(this%l%layoutnumber,dubuf)
             call conf_geometry_mapped_for_UGRDTD (&
             &conf_conflicts, &
-            &this%sgg,this%sggMiEx,this%sggMiEy,this%sggMiEz,this%sggMiHx,this%sggMiHy,this%sggMiHz, &
+            &this%sgg,this%media%sggMiEx,this%media%sggMiEy,this%media%sggMiEz,this%media%sggMiHx,this%media%sggMiHy,this%media%sggMiHz, &
             &this%fullsize, this%SINPML_fullsize,this%l%layoutnumber,conf_err,this%l%verbose);
             !call conf_geometry_mapped_for_UGRDTD (sgg, fullsize, this%SINPML_fullsize,this%l%layoutnumber,conf_err,this%l%verbose); //refactor JUL15
             if(conf_err==0)then

--- a/src_main_pub/timestepping.F90
+++ b/src_main_pub/timestepping.F90
@@ -104,6 +104,7 @@ module Solver_mod
       integer (kind=4) :: initialtimestep, lastexecutedtimestep, ini_save, n_info, n
 
       type(bounds_t) :: bounds
+      type (EpsMuTimeScale_input_parameters_t) :: EpsMuTimeScale_input_parameters
 
       logical :: parar, everflushed = .false., still_planewave_time
 
@@ -232,7 +233,7 @@ module Solver_mod
       this%control%size = input%size
       this%control%MEDIOEXTRA = input%MEDIOEXTRA
       this%control%facesNF2FF = input%facesNF2FF
-      !this%control%EpsMuTimeScale_input_parameters = input%EpsMuTimeScale_input_parameters
+      this%EpsMuTimeScale_input_parameters = input%EpsMuTimeScale_input_parameters
 
 #ifdef CompileWithConformal
       this%control%input_conformal_flag = input%input_conformal_flag
@@ -1986,8 +1987,8 @@ contains
 #ifdef CompileWithPrescale
          if (this%control%permitscaling) then
 #ifndef miguelPscaleStandAlone
-            if ((sgg%tiempo(this%n)>=EpsMuTimeScale_input_parameters%tini).and.&
-                &(sgg%tiempo(this%n)<=EpsMuTimeScale_input_parameters%tend)) then
+            if ((sgg%tiempo(this%n)>=this%EpsMuTimeScale_input_parameters%tini).and.&
+                &(sgg%tiempo(this%n)<=this%EpsMuTimeScale_input_parameters%tend)) then
 #endif
              call updateconstants(sgg,this%n,this%thereare,this%g%g1,this%g%g2,this%g%gM1,this%g%gM2, & 
                                Idxe,Idye,Idze,Idxh,Idyh,Idzh, &  !needed by  CPML to be updated
@@ -1996,7 +1997,7 @@ contains
                                this%control%sgbcDispersive,this%control%finaltimestep, &
                                eps0,mu0, &
                                this%control%simu_devia, &
-                               EpsMuTimeScale_input_parameters,pscale_alpha,this%still_planewave_time &
+                               this%EpsMuTimeScale_input_parameters,pscale_alpha,this%still_planewave_time &
 #ifdef CompileWithMPI
                                ,this%control%layoutnumber,this%control%size &
 #endif


### PR DESCRIPTION
Minor change in timestepping to pass EpsMuTimeScale_input_parameters to solver class