### PR TITLE
71 make nfde_rotate the unique way of rotating mpi for nfde and json flows

### DIFF
--- a/src_main_pub/nfde_rotate.F90
+++ b/src_main_pub/nfde_rotate.F90
@@ -26,16 +26,63 @@ contains
       call  rotate_generateThinSlots                 (this, mpidir)
       call  rotate_generateLossyThinSurface          (this, mpidir)
       call  rotate_generateFDMs                      (this, mpidir)
-      call rotate_generateSONDAs                     (this, mpidir)
-      call rotate_generateMasSondas                  (this, mpidir)
-      call rotate_generateBloqueProbes               (this, mpidir)
-      call rotate_generateVolumicProbes              (this, mpidir)
-#ifdef compilewithMTLN      
-      call rotate_mtln                               (this, mpidir)
+      call  rotate_generateSONDAs                     (this, mpidir)
+      call  rotate_generateMasSondas                  (this, mpidir)
+      call  rotate_generateBloqueProbes               (this, mpidir)
+      call  rotate_generateVolumicProbes              (this, mpidir)
+#ifdef CompileWithMTLN
+      call  rotate_mtln                               (this, mpidir)
 #endif
 
       return
    end subroutine nfde_rotate
+
+#ifdef CompileWithMTLN
+   subroutine rotate_mtln(this, mpidir)
+      type(Parseador_t), intent(inout) :: this          
+      integer(kind=4) :: mpidir
+      type(mtln_t), pointer :: old_mtln => null()
+      integer(kind=4) :: i, j
+      integer(kind=4) :: x, y, z, or
+
+      allocate(old_mtln, source = this%mtln)
+      do i = 1, size(old_mtln%cables)
+         do j = 1, size(old_mtln%cables(i)%ptr%segments)
+            x = old_mtln%cables(i)%ptr%segments(j)%x
+            y = old_mtln%cables(i)%ptr%segments(j)%y
+            z = old_mtln%cables(i)%ptr%segments(j)%z
+            or = old_mtln%cables(i)%ptr%segments(j)%orientation
+            if (mpidir == 2) then 
+               this%mtln%cables(i)%ptr%segments(j)%x = z
+               this%mtln%cables(i)%ptr%segments(j)%y = x
+               this%mtln%cables(i)%ptr%segments(j)%z = y
+               select case(abs(or))
+               case(1)
+                  this%mtln%cables(i)%ptr%segments(j)%orientation = sign(2, or)
+               case(2)
+                  this%mtln%cables(i)%ptr%segments(j)%orientation = sign(3, or)
+               case(3)
+                  this%mtln%cables(i)%ptr%segments(j)%orientation = sign(1, or)
+               end select
+            else if (mpidir == 1) then 
+               this%mtln%cables(i)%ptr%segments(j)%x = y
+               this%mtln%cables(i)%ptr%segments(j)%y = z
+               this%mtln%cables(i)%ptr%segments(j)%z = x
+               select case(abs(old_mtln%cables(i)%ptr%segments(j)%orientation))
+               case(1)
+                  this%mtln%cables(i)%ptr%segments(j)%orientation = sign(3, or)
+               case(2)
+                  this%mtln%cables(i)%ptr%segments(j)%orientation = sign(1, or)
+               case(3)
+                  this%mtln%cables(i)%ptr%segments(j)%orientation = sign(2, or)
+               end select
+            end if
+         end do
+      end do
+      deallocate(old_mtln)
+   end subroutine
+#endif
+
 
    subroutine rotate_generateSpaceSteps (this, mpidir)
       type(Parseador_t), intent(inout) :: this          

--- a/src_main_pub/nfde_rotate.F90
+++ b/src_main_pub/nfde_rotate.F90
@@ -30,8 +30,9 @@ contains
       call rotate_generateMasSondas                  (this, mpidir)
       call rotate_generateBloqueProbes               (this, mpidir)
       call rotate_generateVolumicProbes              (this, mpidir)
-
-
+#ifdef compilewithMTLN      
+      call rotate_mtln                               (this, mpidir)
+#endif
 
       return
    end subroutine nfde_rotate

--- a/src_main_pub/nfde_types.F90
+++ b/src_main_pub/nfde_types.F90
@@ -823,7 +823,6 @@ module NFDETypes_m
    end type t_linea_t
    !--->
    type, public :: t_NFDE_FILE_t
-      integer(kind=4) mpidir !x=1,y=2,z=3
       integer(kind=8) :: targ
       !--->
       integer(kind=8) :: numero

--- a/src_main_pub/semba_fdtd.F90
+++ b/src_main_pub/semba_fdtd.F90
@@ -90,7 +90,6 @@ contains
       integer(kind=4) :: finaltimestepantesdecorregir,NEWfinaltimestep,thefileno
       integer(kind=4) :: statuse
       integer(kind=4) :: status, i, field
-      integer(kind=4) :: verdadero_mpidir
       integer(kind=4) :: my_iostat
 
 
@@ -332,7 +331,7 @@ contains
    call MPI_Barrier (SUBCOMM_MPI, this%l%ierr)
 #endif
 
-   call nfde_rotate (parser,NFDE_FILE%mpidir)
+   call nfde_rotate (parser,this%l%mpidir)
 
 #ifdef CompileWithMPI            
    call MPI_Barrier (SUBCOMM_MPI, this%l%ierr)
@@ -939,12 +938,12 @@ contains
    
       if (trim(adjustl(this%l%extension))=='.nfde') then 
 #ifdef CompilePrivateVersion   
-            ! if(newrotate) NFDE_FILE%mpidir=3 !Legacy hardset to avoid newParser rotation
-            parsedProblem => newparser (NFDE_FILE)
-            this%l%thereare_stoch=NFDE_FILE%thereare_stoch
+         parsedProblem => newparser (NFDE_FILE)
+         ! this%l%mpidir = NFDE_FILE%mpidir
+         this%l%thereare_stoch=NFDE_FILE%thereare_stoch
 #else
-            print *,'Not compiled with cargaNFDEINDEX'
-            stop
+         print *,'Not compiled with cargaNFDEINDEX'
+         stop
 #endif
       
 #ifdef CompileWithSMBJSON

--- a/src_main_pub/semba_fdtd.F90
+++ b/src_main_pub/semba_fdtd.F90
@@ -79,7 +79,6 @@ contains
       logical :: dummylog,l_auxinput, l_auxoutput, ThereArethinslots
       logical :: hayinput
       logical :: lexis
-      logical :: newrotate
 
       character(len=BUFSIZE) :: f= ' ', chain = ' ', chain3 = ' ',chain4 = ' ', chaindummy= ' '
       character(len=BUFSIZE_LONG) :: slices = ' '
@@ -107,11 +106,7 @@ contains
       integer(kind=4) :: conf_err
 
       call initEntrada(this%l) 
-#ifdef CompileWithSMBJSON
-      newrotate=.false.
-#else
-      newrotate=.true.
-#endif
+
       this%eps0= 8.8541878176203898505365630317107502606083701665994498081024171524053950954599821142852891607182008932e-12
       this%mu0 = 1.2566370614359172953850573533118011536788677597500423283899778369231265625144835994512139301368468271e-6
       this%cluz=1.0_RKIND/sqrt(this%eps0*this%mu0)
@@ -334,22 +329,20 @@ contains
    this%sgg%nEntradaRoot=trim (adjustl(this%l%nEntradaRoot))
 
 #ifdef CompileWithMPI            
-      call MPI_Barrier (SUBCOMM_MPI, this%l%ierr)
+   call MPI_Barrier (SUBCOMM_MPI, this%l%ierr)
 #endif
 
-      if(newrotate) then      
-         call nfde_rotate (parser,NFDE_FILE%mpidir)
-      end if 
+   call nfde_rotate (parser,NFDE_FILE%mpidir)
 
 #ifdef CompileWithMPI            
-         call MPI_Barrier (SUBCOMM_MPI, this%l%ierr)
+   call MPI_Barrier (SUBCOMM_MPI, this%l%ierr)
 #endif
 
 #ifdef CompileWithMTLN   
-      if (parser%general%mtlnProblem) then 
-         call solver%launch_mtln_simulation(parser%mtln, this%l%nEntradaRoot, this%l%layoutnumber) 
-         STOP
-      end if
+   if (parser%general%mtlnProblem) then 
+      call solver%launch_mtln_simulation(parser%mtln, this%l%nEntradaRoot, this%l%layoutnumber) 
+      STOP
+   end if
 #endif
 
 #ifdef CompileWithHDF
@@ -946,7 +939,7 @@ contains
    
       if (trim(adjustl(this%l%extension))=='.nfde') then 
 #ifdef CompilePrivateVersion   
-            if(newrotate) NFDE_FILE%mpidir=3 !Legacy hardset to avoid newParser rotation
+            ! if(newrotate) NFDE_FILE%mpidir=3 !Legacy hardset to avoid newParser rotation
             parsedProblem => newparser (NFDE_FILE)
             this%l%thereare_stoch=NFDE_FILE%thereare_stoch
 #else

--- a/test/pyWrapper/test_full_system.py
+++ b/test/pyWrapper/test_full_system.py
@@ -332,51 +332,53 @@ def test_unshielded_multiwires(tmp_path):
     assert np.corrcoef(solved_1, p_expected['current_1'])[0,1] > 0.999
 
 
-@mtln_skip
+@no_mpi_skip
+def test_towelHanger_mpi(tmp_path):
+    fn = CASES_FOLDER + 'towelHanger/towelHanger_mpi.fdtd.json'
+    mpidir = ["x","y","z"]
+    for i in range(3):
+        solver = FDTD(input_filename=fn, path_to_exe=SEMBA_EXE,
+                    run_in_folder=tmp_path, flags=['-mpidir ' + mpidir[i]], 
+                    mpi_command='mpirun -np 1',)
+        for j in range(len(solver["mesh"]["coordinates"])):
+            cs = [0,0,0]
+            cs[0] = solver["mesh"]["coordinates"][j]["relativePosition"][(0 + i)%3]
+            cs[1] = solver["mesh"]["coordinates"][j]["relativePosition"][(1 + i)%3]
+            cs[2] = solver["mesh"]["coordinates"][j]["relativePosition"][(2 + i)%3]
+            solver["mesh"]["coordinates"][j]["relativePosition"] = cs
+
+        intervals = [[[0,0,0], [0,0,0]]]
+        intervals[0][0][0] = solver["mesh"]["elements"][2]["intervals"][0][0][(0 + i)%3]
+        intervals[0][0][1] = solver["mesh"]["elements"][2]["intervals"][0][0][(1 + i)%3]
+        intervals[0][0][2] = solver["mesh"]["elements"][2]["intervals"][0][0][(2 + i)%3]
+        intervals[0][1][0] = solver["mesh"]["elements"][2]["intervals"][0][1][(0 + i)%3]
+        intervals[0][1][1] = solver["mesh"]["elements"][2]["intervals"][0][1][(1 + i)%3]
+        intervals[0][1][2] = solver["mesh"]["elements"][2]["intervals"][0][1][(2 + i)%3]
+
+        solver["mesh"]["elements"][2]["intervals"] = intervals
+        solver.cleanUp()
+        solver.run()
+
+        p_solved = [Probe(solver.getSolvedProbeFilenames("wire_start")[0]),
+                    Probe(solver.getSolvedProbeFilenames("wire_mid")[0]),
+                    Probe(solver.getSolvedProbeFilenames("wire_end")[0])]
+
+        p_expected = [Probe(OUTPUTS_FOLDER+'towelHanger.fdtd_wire_start_Wz_27_25_30_s1.dat'),
+                    Probe(OUTPUTS_FOLDER+'towelHanger.fdtd_wire_mid_Wx_35_25_32_s5.dat'),
+                    Probe(OUTPUTS_FOLDER+'towelHanger.fdtd_wire_end_Wz_43_25_30_s4.dat')]
+
+        for i in range(3):
+            solved = np.interp(p_expected[i]['time'].to_numpy(), 
+                            p_solved[i]['time'].to_numpy(), 
+                            p_solved[i]['current_0'].to_numpy())
+            assert np.corrcoef(solved, p_expected[i]['current_0'])[0,1] > 0.999
+    
+    
+
 def test_towelHanger(tmp_path):
     fn = CASES_FOLDER + 'towelHanger/towelHanger.fdtd.json'
     solver = FDTD(input_filename=fn, path_to_exe=SEMBA_EXE,
                   run_in_folder=tmp_path)
-    solver['materials'][0] = createWire(id = 1, r = 0.1e-3)
-
-    p_solved = [Probe(solver.getSolvedProbeFilenames("wire_start")[0]),
-                   Probe(solver.getSolvedProbeFilenames("wire_mid")[0]),
-                   Probe(solver.getSolvedProbeFilenames("wire_end")[0])]
-
-    p_expected = [Probe(OUTPUTS_FOLDER+'towelHanger.fdtd_wire_start_Wz_27_25_30_s1.dat'),
-                  Probe(OUTPUTS_FOLDER+'towelHanger.fdtd_wire_mid_Wx_35_25_32_s5.dat'),
-                  Probe(OUTPUTS_FOLDER+'towelHanger.fdtd_wire_end_Wz_43_25_30_s4.dat')]
-
-    assert np.allclose(p_expected[0]['current'], p_solved[0]['current'], rtol=5e-3, atol=5e-4)
-    assert np.allclose(p_expected[1]['current'], p_solved[1]['current'], rtol=5e-3, atol=5e-4)
-    assert np.allclose(p_expected[2]['current'], p_solved[2]['current'], rtol=5e-3, atol=5e-4)
-
-@no_mtln_skip
-def test_towelHanger(tmp_path):
-    fn = CASES_FOLDER + 'towelHanger/towelHanger.fdtd.json'
-    solver = FDTD(input_filename=fn, path_to_exe=SEMBA_EXE,
-                  run_in_folder=tmp_path)
-    solver['materials'][0] = createUnshieldedWire(id = 1, lpul = 6.5183032590978384e-07, cpul = 1.7046017451862063e-11)        
-    solver.run()
-
-    p_solved = [Probe(solver.getSolvedProbeFilenames("wire_start")[0]),
-                   Probe(solver.getSolvedProbeFilenames("wire_mid")[0]),
-                   Probe(solver.getSolvedProbeFilenames("wire_end")[0])]
-
-    p_expected = [Probe(OUTPUTS_FOLDER+'towelHanger.fdtd_wire_start_Wz_27_25_30_s1.dat'),
-                  Probe(OUTPUTS_FOLDER+'towelHanger.fdtd_wire_mid_Wx_35_25_32_s5.dat'),
-                  Probe(OUTPUTS_FOLDER+'towelHanger.fdtd_wire_end_Wz_43_25_30_s4.dat')]
-
-    assert np.allclose(p_expected[0]['current'], -p_solved[0]['current_0'], rtol=5e-3, atol=5e-4)
-    assert np.allclose(p_expected[1]['current'], -p_solved[1]['current_0'], rtol=5e-3, atol=5e-4)
-    assert np.allclose(p_expected[2]['current'],  p_solved[2]['current_0'], rtol=5e-3, atol=5e-4)
-
-@no_mtln_skip
-def test_towelHanger(tmp_path):
-    fn = CASES_FOLDER + 'towelHanger/towelHanger.fdtd.json'
-    solver = FDTD(input_filename=fn, path_to_exe=SEMBA_EXE,
-                  run_in_folder=tmp_path)
-    solver['materials'][0] = createUnshieldedWire(id = 1, lpul = 6.5183032590978384e-07, cpul = 1.7046017451862063e-11)        
     solver.run()
 
     p_solved = [Probe(solver.getSolvedProbeFilenames("wire_start")[0]),
@@ -448,7 +450,7 @@ def test_towel_rack_with_and_without_shorting_plane(tmp_path):
     # plt.savefig('tmp-plot.png')
     # plt.show()
 
-    # Expect the shorting plane not chaning the impedance at low frequencies.
+    # Expect the shorting plane not changing the impedance at low frequencies.
     assert np.allclose(
         np.abs(Z_in_w[freqs < 1e6]), 
         np.abs(Z_in_wo[freqs < 1e6]), 

--- a/test/rotate/CMakeLists.txt
+++ b/test/rotate/CMakeLists.txt
@@ -20,8 +20,13 @@ add_library(
     "test_rotate_generateMasSondas.F90"
     "test_rotate_generateBloqueProbes.F90" 
     "test_rotate_generateVolumicProbes.F90"
-    "test_rotate_mtln.F90"
 )
+    
+if(SEMBA_FDTD_ENABLE_MTLN)
+    target_sources(rotate_test_fortran PRIVATE
+        "test_rotate_mtln.F90"
+    )
+endif()
 
 target_link_libraries(rotate_test_fortran
     smbjson

--- a/test/rotate/CMakeLists.txt
+++ b/test/rotate/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(
     "test_rotate_generateMasSondas.F90"
     "test_rotate_generateBloqueProbes.F90" 
     "test_rotate_generateVolumicProbes.F90"
+    "test_rotate_mtln.F90"
 )
 
 target_link_libraries(rotate_test_fortran

--- a/test/rotate/rotate_tests.h
+++ b/test/rotate/rotate_tests.h
@@ -17,6 +17,10 @@ extern "C" int test_rotate_generate_mas_sondas();
 extern "C" int test_rotate_generate_bloque_probes();
 extern "C" int test_rotate_generate_volumic_probes();
 
+#ifdef CompileWithMTLN
+extern "C" int test_rotate_mtln();
+#endif
+
 
 TEST(rotate, rotate_spaceSteps_test)    { EXPECT_EQ(0, test_rotate_generate_space_steps()); }
 TEST(rotate, rotate_currentFieldSources_test) { EXPECT_EQ(0, test_rotate_generate_current_field_sources()); }
@@ -34,5 +38,8 @@ TEST(rotate, rotate_sondas_test)        { EXPECT_EQ(0, test_rotate_generate_sond
 TEST(rotate, rotate_masSondas_test)     { EXPECT_EQ(0, test_rotate_generate_mas_sondas()); }
 TEST(rotate, rotate_bloqueProbes_test)  { EXPECT_EQ(0, test_rotate_generate_bloque_probes()); }
 TEST(rotate, rotate_volumicProbes_test) { EXPECT_EQ(0, test_rotate_generate_volumic_probes()); }
+#ifdef CompileWithMTLN
+TEST(rotate, rotate_mtln_test) { EXPECT_EQ(0, test_rotate_mtln()); }
+#endif
 
 

--- a/test/rotate/test_rotate_mtln.F90
+++ b/test/rotate/test_rotate_mtln.F90
@@ -1,0 +1,52 @@
+module test_rotate_mtln_m
+    use mtln_types_m
+    use smbjson_m
+    use nfde_rotate_m
+    use rotate_testingTools
+    implicit none
+
+contains
+
+integer function test_rotate_mtln() bind(C) result(err)
+    type(Parseador_t) :: this
+    integer(kind=4) :: mpidir
+    integer :: test_err = 0
+    type(cable_t), target :: cable
+    allocate(this%mtln)
+    allocate(this%mtln%cables(1))
+    allocate(cable%segments(1))
+
+    cable%segments(1)%x = 1
+    cable%segments(1)%y = 2 
+    cable%segments(1)%z = 3
+    cable%segments(1)%orientation = 1
+    this%mtln%cables(1)%ptr => cable
+
+    mpidir = 2
+    call rotate_mtln(this, mpidir)
+    call expect_eq_int(test_err, 3, this%mtln%cables(1)%ptr%segments(1)%x, "rotate_mtln: x should be rotated with mpidir 2")
+    call expect_eq_int(test_err, 1, this%mtln%cables(1)%ptr%segments(1)%y, "rotate_mtln: y should be rotated with mpidir 2")
+    call expect_eq_int(test_err, 2, this%mtln%cables(1)%ptr%segments(1)%z, "rotate_mtln: z should be rotated with mpidir 2")
+    call expect_eq_int(test_err, 2, this%mtln%cables(1)%ptr%segments(1)%orientation, "rotate_mtln: orientation should be rotated with mpidir 2")
+
+    cable%segments(1)%x = 1
+    cable%segments(1)%y = 2 
+    cable%segments(1)%z = 3
+    cable%segments(1)%orientation = 1
+    this%mtln%cables(1)%ptr => cable
+
+    mpidir = 1
+    call rotate_mtln(this, mpidir)
+    call expect_eq_int(test_err, 2, this%mtln%cables(1)%ptr%segments(1)%x, "rotate_mtln: x should be rotated with mpidir 1")
+    call expect_eq_int(test_err, 3, this%mtln%cables(1)%ptr%segments(1)%y, "rotate_mtln: y should be rotated with mpidir 1")
+    call expect_eq_int(test_err, 1, this%mtln%cables(1)%ptr%segments(1)%z, "rotate_mtln: z should be rotated with mpidir 1")
+    call expect_eq_int(test_err, 3, this%mtln%cables(1)%ptr%segments(1)%orientation, "rotate_mtln: orientation should be rotated with mpidir 1")
+
+    deallocate(cable%segments)
+    deallocate(this%mtln%cables)
+    deallocate(this%mtln)
+    err = test_err
+
+end function
+
+end module

--- a/testData/cases/towelHanger/towelHanger_mpi.fdtd.json
+++ b/testData/cases/towelHanger/towelHanger_mpi.fdtd.json
@@ -1,0 +1,117 @@
+    {
+    "format": "FDTD Input file",
+    "__comments": "",
+
+    "general": {
+        "timeStep": 1e-12,
+        "numberOfSteps": 2000
+    },
+  
+    "boundary": {
+        "all": {
+            "type": "pml",
+            "layers": 6, 
+            "order": 2.0,
+            "reflection": 0.001
+        }
+    },
+
+    "materials": [
+        {
+            "id": 1,
+            "type": "wire",
+            "radius": 0.1e-3,
+            "resistancePerMeter": 0.0,
+            "inductancePerMeter": 0.0
+        },
+        {
+            "id": 2,
+            "type": "terminal",
+            "terminations": [{
+                "type": "series", 
+                "resistance" : 50.0}]
+        },
+        {
+            "id": 3,
+            "type": "terminal",
+            "terminations": [{
+                "type": "short"}]
+        },
+        {
+            "name": "copper",
+            "id": 4,
+            "type": "pec"
+        }
+    ],
+
+    "mesh": {
+        "grid": {
+            "numberOfCells": [60, 60, 60],
+            "steps": { "x": [0.01], "y": [0.01], "z": [0.01] }
+        },
+        "coordinates": [
+            {"id": 1, "relativePosition": [27, 25, 30]},
+            {"id": 2, "relativePosition": [27, 25, 32]},
+            {"id": 3, "relativePosition": [43, 25, 32]},
+            {"id": 4, "relativePosition": [43, 25, 30]},
+            {"id": 5, "relativePosition": [35, 25, 32]},
+            {"id": 6, "relativePosition": [35, 25, 32]}
+        ],
+        "elements": [
+            {"id": 1, "type": "node", "coordinateIds": [1]},
+            {"id": 2, "type": "polyline", "coordinateIds": [1, 2, 5, 3, 4] },
+            {"id": 3, "type": "cell", "name": "ground_plane", "intervals": [[[25, 20, 30], [45, 30, 30]]] },
+            {"id": 4, "type": "node", "coordinateIds": [4]},
+            {"id": 5, "type": "cell", "intervals": [[[1, 1, 1], [59, 59, 59]]] },
+            {"id": 6, "type": "node", "coordinateIds": [5]}
+        ]
+    },
+
+    "materialAssociations": [
+        { 
+                        "name": "wire",
+            "materialId": 1,
+            "initialTerminalId": 2,
+            "endTerminalId": 3,
+            "elementIds": [2]
+        },
+        { 
+                        "materialId" : 4,
+            "elementIds": [3]
+        }
+    ],
+    "sources": [
+        {
+            "name" : "terminal_source",
+            "type" : "generator",
+            "magnitudeFile" : "towelHanger.exc",
+            "elementIds" : [1],
+            "field" : "voltage"
+        }
+    ],
+
+    "probes": [
+        {
+            "name": "wire_start",
+            "type": "wire",
+            "field": "current",
+            "elementIds": [1],
+            "domain": { "type": "time" }
+        },
+        {
+            "name": "wire_end",
+            "type": "wire",
+            "field": "current",
+            "elementIds": [4],
+            "domain": { "type": "time" }
+        },
+        {
+            "name": "wire_mid",
+            "type": "wire",
+            "field": "current",
+            "elementIds": [6],
+            "domain": { "type": "time" }
+        }
+
+    ]
+}


### PR DESCRIPTION
NFDE files had the rotation when using mpidir hardcoded into the parsing process. The _nfde_rotate_ function performs the rotation as a separate function, but the separation is not complete:
- the rotation is still inside the nfde parser, but bypassed.
- json files are not being rotated