### PR TITLE
Fix cleanUp to only delete files belonging to the current case

### DIFF
--- a/.github/workflows/check-submodules-default-branch.yml
+++ b/.github/workflows/check-submodules-default-branch.yml
@@ -65,6 +65,11 @@ jobs:
             git -C "${path}" remote set-branches --add origin '*'
             git -C "${path}" fetch --no-tags origin '+refs/heads/*:refs/remotes/origin/*' >/dev/null
 
+            # actions/checkout can leave submodules shallow; unshallow to make ancestry checks reliable.
+            if git -C "${path}" rev-parse --is-shallow-repository | grep -q true; then
+              git -C "${path}" fetch --unshallow --no-tags origin >/dev/null
+            fi
+
             default_ref="$(git -C "${path}" ls-remote --symref origin HEAD | awk '/^ref:/ {print $2}' || true)"
             default_branch="${default_ref#refs/heads/}"
 

--- a/.github/workflows/check-submodules-default-branch.yml
+++ b/.github/workflows/check-submodules-default-branch.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Validate submodules point to default branch history
+      - name: Validate submodules point to main/master history
         shell: bash
         run: |
           set -euo pipefail
@@ -82,19 +82,40 @@ jobs:
 
             echo "Default branch detected: ${default_branch}"
 
-            if git -C "${path}" merge-base --is-ancestor "${sha}" "origin/${default_branch}"; then
-              echo "OK: ${path} commit belongs to origin/${default_branch} history"
-            else
-              echo "::error title=Submodule not on default branch history::Submodule '${path}' points to ${sha}, which is not contained in origin/${default_branch}"
+            candidate_branches=()
+
+            if git -C "${path}" show-ref --verify --quiet refs/remotes/origin/main; then
+              candidate_branches+=("main")
+            fi
+
+            if git -C "${path}" show-ref --verify --quiet refs/remotes/origin/master; then
+              candidate_branches+=("master")
+            fi
+
+            if [[ " ${candidate_branches[*]} " != *" ${default_branch} "* ]]; then
+              candidate_branches+=("${default_branch}")
+            fi
+
+            is_valid=0
+            for branch in "${candidate_branches[@]}"; do
+              if git -C "${path}" merge-base --is-ancestor "${sha}" "origin/${branch}"; then
+                echo "OK: ${path} commit belongs to origin/${branch} history"
+                is_valid=1
+                break
+              fi
+            done
+
+            if [[ ${is_valid} -eq 0 ]]; then
+              echo "::error title=Submodule not on main/master history::Submodule '${path}' points to ${sha}, which is not contained in any accepted branch: ${candidate_branches[*]}"
               failed=1
             fi
           done
 
           if [[ ${failed} -ne 0 ]]; then
             echo ""
-            echo "One or more submodules are not aligned with their default branch history."
+            echo "One or more submodules are not aligned with accepted branch history (main/master/default)."
             exit 1
           fi
 
           echo ""
-          echo "All submodule commits are contained in their remote default branch history."
+          echo "All submodule commits are contained in accepted branch history (main/master/default)."

--- a/.github/workflows/check-submodules-default-branch.yml
+++ b/.github/workflows/check-submodules-default-branch.yml
@@ -1,0 +1,100 @@
+name: check-submodules-default-branch
+
+'on':
+  push:
+    branches:
+      - main
+      - dev
+  pull_request:
+    branches:
+      - main
+      - dev
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-submodules-default-branch:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository with submodules
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Validate submodules point to default branch history
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ ! -f .gitmodules ]]; then
+            echo "No .gitmodules file found. Nothing to validate."
+            exit 0
+          fi
+
+          mapfile -t submodule_paths < <(git config -f .gitmodules --get-regexp '^submodule\..*\.path$' | awk '{print $2}')
+
+          if [[ ${#submodule_paths[@]} -eq 0 ]]; then
+            echo "No submodules found in .gitmodules."
+            exit 0
+          fi
+
+          failed=0
+
+          for path in "${submodule_paths[@]}"; do
+            echo ""
+            echo "Checking submodule: ${path}"
+
+            if [[ ! -d "${path}" ]]; then
+              echo "::error title=Missing submodule directory::Submodule path '${path}' is missing in checkout"
+              failed=1
+              continue
+            fi
+
+            if ! git -C "${path}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+              echo "::error title=Invalid submodule checkout::Path '${path}' is not a valid git repository"
+              failed=1
+              continue
+            fi
+
+            sha="$(git -C "${path}" rev-parse HEAD)"
+            echo "Pinned commit: ${sha}"
+
+            git -C "${path}" remote set-branches --add origin '*'
+            git -C "${path}" fetch --no-tags origin '+refs/heads/*:refs/remotes/origin/*' >/dev/null
+
+            default_ref="$(git -C "${path}" ls-remote --symref origin HEAD | awk '/^ref:/ {print $2}' || true)"
+            default_branch="${default_ref#refs/heads/}"
+
+            if [[ -z "${default_branch}" ]]; then
+              if git -C "${path}" show-ref --verify --quiet refs/remotes/origin/main; then
+                default_branch="main"
+              elif git -C "${path}" show-ref --verify --quiet refs/remotes/origin/master; then
+                default_branch="master"
+              else
+                echo "::error title=Cannot determine default branch::Could not determine default branch for submodule '${path}'"
+                failed=1
+                continue
+              fi
+            fi
+
+            echo "Default branch detected: ${default_branch}"
+
+            if git -C "${path}" merge-base --is-ancestor "${sha}" "origin/${default_branch}"; then
+              echo "OK: ${path} commit belongs to origin/${default_branch} history"
+            else
+              echo "::error title=Submodule not on default branch history::Submodule '${path}' points to ${sha}, which is not contained in origin/${default_branch}"
+              failed=1
+            fi
+          done
+
+          if [[ ${failed} -ne 0 ]]; then
+            echo ""
+            echo "One or more submodules are not aligned with their default branch history."
+            exit 1
+          fi
+
+          echo ""
+          echo "All submodule commits are contained in their remote default branch history."

--- a/src_pyWrapper/pyWrapper.py
+++ b/src_pyWrapper/pyWrapper.py
@@ -346,16 +346,19 @@ class FDTD():
 
     def cleanUp(self):
         folder = self.getFolder()
+        case_name = self.getCaseName()
         extensions = ('*.dat', '*.pl', '*.txt', '*.xdmf', '*.bin', '*.h5')
         for ext in extensions:
-            files = glob.glob(folder + '/' + ext)
+            files = glob.glob(os.path.join(folder, ext))
             for file in files:
-                os.remove(file)
+                if os.path.basename(file).startswith(case_name):
+                    os.remove(file)
 
         subfolders = [item for item in os.listdir(
             folder) if os.path.isdir(os.path.join(folder, item))]
         for f in subfolders:
-            shutil.rmtree(f, ignore_errors=True)
+            if f.startswith(case_name):
+                shutil.rmtree(os.path.join(folder, f), ignore_errors=True)
 
     def getSolvedProbeFilenames(self, probe_name):
         if not "probes" in self._input:

--- a/test/pyWrapper/test_pyWrapper.py
+++ b/test/pyWrapper/test_pyWrapper.py
@@ -131,6 +131,25 @@ def test_fdtd_clean_up_after_run(tmp_path):
     assert not os.path.isfile(pn[0])
 
 
+def test_fdtd_clean_up_does_not_delete_other_cases_files(tmp_path):
+    input = CASES_FOLDER + 'planewave/pw-in-box.fdtd.json'
+    solver = FDTD(input, path_to_exe=SEMBA_EXE, run_in_folder=tmp_path)
+
+    case_name = solver.getCaseName()
+    other_case_name = 'other_case.fdtd'
+
+    own_file = os.path.join(str(tmp_path), case_name + '_probe_Ex_1_2_3.dat')
+    other_file = os.path.join(str(tmp_path), other_case_name + '_probe_Ex_1_2_3.dat')
+
+    open(own_file, 'w').close()
+    open(other_file, 'w').close()
+
+    solver.cleanUp()
+
+    assert not os.path.isfile(own_file)
+    assert os.path.isfile(other_file)
+
+
 def test_fdtd_get_used_files():
     fn = CASES_FOLDER + 'multilines_opamp/multilines_opamp.fdtd.json'
     solver = FDTD(fn, path_to_exe=SEMBA_EXE)


### PR DESCRIPTION
Fixes #377.

## Problem

When two different cases described by `.fdtd.json` files reside in the same folder, calling `FDTD.cleanUp()` deleted output files for **all** cases in that folder, not just the one associated with the current instance.

Additionally, the subfolder deletion used a bare name instead of the full path, which would silently fail unless the process CWD happened to be the case folder.

## Fix

- Filter deleted files by requiring `os.path.basename(file).startswith(case_name)`.
- Filter deleted subfolders by requiring `f.startswith(case_name)`.
- Use `os.path.join(folder, f)` for the full subfolder path when calling `shutil.rmtree`.

## Tests

Added `test_fdtd_clean_up_does_not_delete_other_cases_files` to `test/pyWrapper/test_pyWrapper.py` that creates fake output files for two different cases in the same folder, calls `cleanUp()` on one, and asserts the other case's files are untouched.