### PR TITLE
Fix cleanUp to only delete files belonging to the current case

### DIFF
--- a/src_pyWrapper/pyWrapper.py
+++ b/src_pyWrapper/pyWrapper.py
@@ -346,16 +346,19 @@ class FDTD():
 
     def cleanUp(self):
         folder = self.getFolder()
+        case_name = self.getCaseName()
         extensions = ('*.dat', '*.pl', '*.txt', '*.xdmf', '*.bin', '*.h5')
         for ext in extensions:
-            files = glob.glob(folder + '/' + ext)
+            files = glob.glob(os.path.join(folder, ext))
             for file in files:
-                os.remove(file)
+                if os.path.basename(file).startswith(case_name):
+                    os.remove(file)
 
         subfolders = [item for item in os.listdir(
             folder) if os.path.isdir(os.path.join(folder, item))]
         for f in subfolders:
-            shutil.rmtree(f, ignore_errors=True)
+            if f.startswith(case_name):
+                shutil.rmtree(os.path.join(folder, f), ignore_errors=True)
 
     def getSolvedProbeFilenames(self, probe_name):
         if not "probes" in self._input:

--- a/test/pyWrapper/test_pyWrapper.py
+++ b/test/pyWrapper/test_pyWrapper.py
@@ -131,6 +131,25 @@ def test_fdtd_clean_up_after_run(tmp_path):
     assert not os.path.isfile(pn[0])
 
 
+def test_fdtd_clean_up_does_not_delete_other_cases_files(tmp_path):
+    input = CASES_FOLDER + 'planewave/pw-in-box.fdtd.json'
+    solver = FDTD(input, path_to_exe=SEMBA_EXE, run_in_folder=tmp_path)
+
+    case_name = solver.getCaseName()
+    other_case_name = 'other_case.fdtd'
+
+    own_file = os.path.join(str(tmp_path), case_name + '_probe_Ex_1_2_3.dat')
+    other_file = os.path.join(str(tmp_path), other_case_name + '_probe_Ex_1_2_3.dat')
+
+    open(own_file, 'w').close()
+    open(other_file, 'w').close()
+
+    solver.cleanUp()
+
+    assert not os.path.isfile(own_file)
+    assert os.path.isfile(other_file)
+
+
 def test_fdtd_get_used_files():
     fn = CASES_FOLDER + 'multilines_opamp/multilines_opamp.fdtd.json'
     solver = FDTD(fn, path_to_exe=SEMBA_EXE)


### PR DESCRIPTION
Fixes #377.

## Problem

When two different cases described by `.fdtd.json` files reside in the same folder, calling `FDTD.cleanUp()` deleted output files for **all** cases in that folder, not just the one associated with the current instance.

Additionally, the subfolder deletion used a bare name instead of the full path, which would silently fail unless the process CWD happened to be the case folder.

## Fix

- Filter deleted files by requiring `os.path.basename(file).startswith(case_name)`.
- Filter deleted subfolders by requiring `f.startswith(case_name)`.
- Use `os.path.join(folder, f)` for the full subfolder path when calling `shutil.rmtree`.

## Tests

Added `test_fdtd_clean_up_does_not_delete_other_cases_files` to `test/pyWrapper/test_pyWrapper.py` that creates fake output files for two different cases in the same folder, calls `cleanUp()` on one, and asserts the other case's files are untouched.