### PR TITLE
Remove open terminal type (closes #385)

### DIFF
--- a/doc/fdtdjson.md
+++ b/doc/fdtdjson.md
@@ -457,7 +457,6 @@ A `terminal` models a lumped circuit which is assumed to located at one end of a
 Each entry in `terminations` is specified by a `type`
 
 + `short` if the wire is short-circuited with another wire or with any surface which might be present.
-+ `open` if the wire does not end in an ohmic contact with any other structure.
 + Different configurations of passive circuit elements R, L, and C can be defined:
   + `series` (for RLC series circuits), 
   + `parallel` (for RLC parallel circuits), 

--- a/src_json_parser/smbjson.F90
+++ b/src_json_parser/smbjson.F90
@@ -2198,10 +2198,6 @@ contains
          end if
 
          select case(label)
-          case(J_MAT_TERM_TYPE_OPEN)
-            res%r = 0.0_RKIND
-            res%l = 0.0_RKIND
-            res%c = 0.0_RKIND
           case(J_MAT_TERM_TYPE_SHORT)
             res%r = 0.0_RKIND
             res%l = 0.0_RKIND
@@ -2211,7 +2207,7 @@ contains
             res%l = this%getRealAt(tm, J_MAT_TERM_INDUCTANCE, default=0.0_RKIND)
             res%c = this%getRealAt(tm, J_MAT_TERM_CAPACITANCE, default=1e22_RKIND)
           case default
-            call WarnErrReport("Error reading wire terminal. Holland wires only support open, short, and series terminations", .true.)
+            call WarnErrReport("Error reading wire terminal. Holland wires only support short and series terminations", .true.)
          end select
 
       end function
@@ -2220,11 +2216,11 @@ contains
          character(len=:), allocatable, intent(in) :: label
          integer :: res
          select case (label)
-          case (J_MAT_TERM_TYPE_OPEN)
-            res = MATERIAL_CONS
           case (J_MAT_TERM_TYPE_SERIES)
             res = SERIES_CONS
           case (J_MAT_TERM_TYPE_SHORT)
+            res = MATERIAL_CONS
+          case default
             res = MATERIAL_CONS
          end select
       end function
@@ -3372,8 +3368,10 @@ contains
          integer :: res
          character(:), allocatable :: type
          type = this%getStrAt(termination, J_TYPE)
-         if (type == J_MAT_TERM_TYPE_OPEN) then
-            res = TERMINATION_OPEN
+         if (type == "open") then
+            call WarnErrReport("Termination type 'open' is no longer supported. " // &
+               "Use a 'series' termination with a large resistance instead.", .true.)
+            res = TERMINATION_UNDEFINED
          else if (type == J_MAT_TERM_TYPE_SHORT) then
             res = TERMINATION_SHORT
          else if (type == J_MAT_TERM_TYPE_SERIES) then

--- a/src_json_parser/smbjson_labels.F90
+++ b/src_json_parser/smbjson_labels.F90
@@ -59,7 +59,6 @@ module smbjson_labels_m
    character(len=*), parameter :: J_MAT_LUMPED_CAPACITANCE = "capacitance" 
       
    character(len=*), parameter :: J_MAT_TERM_TERMINATIONS = "terminations"
-   character(len=*), parameter :: J_MAT_TERM_TYPE_OPEN = "open"
    character(len=*), parameter :: J_MAT_TERM_TYPE_SHORT = "short"
    character(len=*), parameter :: J_MAT_TERM_TYPE_SERIES = "series"
    character(len=*), parameter :: J_MAT_TERM_TYPE_PARALLEL = "parallel"

--- a/src_mtln/mtln_solver.F90
+++ b/src_mtln/mtln_solver.F90
@@ -154,7 +154,6 @@ contains
         class(mtln_t) :: this
         integer :: i,j
         integer ::b, c, v_idx, i_idx
-        integer :: n
 ! #ifdef CompileWithMPI
 !         integer(kind=4) :: ierr
 !         call mpi_barrier(subcomm_mpi, ierr)
@@ -176,18 +175,9 @@ contains
                 do j = 1, size(this%network_manager%networks(i)%nodes)
                     b = this%network_manager%networks(i)%nodes(j)%bundle_number
                     c = this%network_manager%networks(i)%nodes(j)%conductor_number
-                    if (.not. this%network_manager%networks(i)%nodes(j)%open) then 
-                        v_idx = this%network_manager%networks(i)%nodes(j)%v_index
-                        i_idx = this%network_manager%networks(i)%nodes(j)%i_index
-                        if (this%bundles(b)%bundle_in_layer) this%bundles(b)%v(c, v_idx) = this%network_manager%networks(i)%nodes(j)%v
-                    else 
-                        if (this%network_manager%networks(i)%nodes(j)%side == TERMINAL_NODE_SIDE_INI) then 
-                            this%bundles(b)%v(c,1) = this%bundles(b)%v(c,1) - 2*dot_product(this%bundles(b)%i_diff(1,c,:), this%bundles(b)%i(:,1))
-                        else if (this%network_manager%networks(i)%nodes(j)%side == TERMINAL_NODE_SIDE_END) then 
-                            n = this%bundles(b)%number_of_divisions
-                            this%bundles(b)%v(c,n+1) = this%bundles(b)%v(c,n+1) + 2*dot_product(this%bundles(b)%i_diff(n,c,:), this%bundles(b)%i(:,n))
-                        end if
-                    end if
+                    v_idx = this%network_manager%networks(i)%nodes(j)%v_index
+                    i_idx = this%network_manager%networks(i)%nodes(j)%i_index
+                    if (this%bundles(b)%bundle_in_layer) this%bundles(b)%v(c, v_idx) = this%network_manager%networks(i)%nodes(j)%v
                 end do
             end do
         end if

--- a/src_mtln/mtln_types.F90
+++ b/src_mtln/mtln_types.F90
@@ -4,7 +4,6 @@ module mtln_types_m
 
    integer, parameter :: TERMINATION_UNDEFINED  = -1
    integer, parameter :: TERMINATION_SHORT      =  1
-   integer, parameter :: TERMINATION_OPEN       =  2
    integer, parameter :: TERMINATION_SERIES     =  3
    integer, parameter :: TERMINATION_PARALLEL   =  4
    integer, parameter :: TERMINATION_RsLCp      =  5

--- a/src_mtln/network.F90
+++ b/src_mtln/network.F90
@@ -16,7 +16,6 @@ module network_m
         real(kind=rkind) :: i
         integer :: bundle_number, conductor_number, v_index, i_index
         integer :: side
-        logical :: open = .false.
     end type
 
 

--- a/src_mtln/preprocess.F90
+++ b/src_mtln/preprocess.F90
@@ -902,32 +902,6 @@ contains
 
     end function
 
-    function writeOpenNode(node, termination, end_node) result(res)
-        type(nw_node_t), intent(in) :: node
-        type(termination_t), intent(in) :: termination
-        character(len=*), intent(in) :: end_node
-        character(len=256), allocatable :: res(:)
-        character(len=256) :: buff
-        character(30) :: line_c, line_g
-
-        write(line_c, *) node%line_c_per_meter*node%step/2
-
-        allocate(res(0))
-        buff = trim("R" // node%name // " " // node%name // " " // end_node//" 1e22")
-        call appendToStringArray(res, buff)
-        buff = trim("I" // node%name // " " // node%name// " 0 " // " dc 0")
-        call appendToStringArray(res, buff)
-        buff = trim("CL" // node%name // " " // node%name // " 0 " // line_c)
-        call appendToStringArray(res, buff)
-        
-        if (node%line_g_per_meter /= 0) then
-            write(line_g, *) 1.0/(node%line_g_per_meter * node%step/2)
-            buff = trim(trim("GL" // node%name) // " " // trim(node%name) // " 0 " // trim(line_g))
-            call appendToStringArray(res, buff)
-        end if    
-
-    end function
-    
     function writeNodeDescription(node, termination, end_node) result(res)
         type(nw_node_t), intent(in) :: node
         type(termination_t), intent(in) :: termination
@@ -951,8 +925,6 @@ contains
             res = writeXYsZpNode(node, termination, end_node, XYZ = "LCR")
         else if (termination%termination_type == TERMINATION_SHORT) then 
             res = writeShortNode(node, termination , end_node)
-        else if (termination%termination_type == TERMINATION_OPEN) then 
-            res = writeOpenNode(node, termination , end_node)
         else if (termination%termination_type == TERMINATION_CIRCUIT) then 
             res = writeModelNode(node, termination , end_node)
         else if (termination%termination_type == TERMINATION_NETWORK) then 
@@ -1145,7 +1117,6 @@ contains
             res%step = step
         end block
 
-        if (node%termination%termination_type == TERMINATION_open) res%open = .true.
         res%source = node%termination%source
 
     contains

--- a/test/smbjson/test_read_holland1981_unshielded.F90
+++ b/test/smbjson/test_read_holland1981_unshielded.F90
@@ -113,14 +113,14 @@ contains
       ex%mtln%networks(1)%connections(1)%nodes(1)%conductor_in_cable = 1
       ex%mtln%networks(1)%connections(1)%nodes(1)%side = TERMINAL_NODE_SIDE_INI
       ex%mtln%networks(1)%connections(1)%nodes(1)%belongs_to_cable =>  ex%mtln%cables(1)%ptr
-      ex%mtln%networks(1)%connections(1)%nodes(1)%termination%termination_type = TERMINATION_OPEN
+      ex%mtln%networks(1)%connections(1)%nodes(1)%termination%termination_type = TERMINATION_SHORT
 
       allocate(ex%mtln%networks(2)%connections(1))
       allocate(ex%mtln%networks(2)%connections(1)%nodes(1))
       ex%mtln%networks(2)%connections(1)%nodes(1)%conductor_in_cable = 1
       ex%mtln%networks(2)%connections(1)%nodes(1)%side = TERMINAL_NODE_SIDE_END
       ex%mtln%networks(2)%connections(1)%nodes(1)%belongs_to_cable =>  ex%mtln%cables(1)%ptr
-      ex%mtln%networks(2)%connections(1)%nodes(1)%termination%termination_type = TERMINATION_OPEN
+      ex%mtln%networks(2)%connections(1)%nodes(1)%termination%termination_type = TERMINATION_SHORT
 
 
    end function

--- a/test/smbjson/test_read_unshielded_multiwires_multipolar_expansion.F90
+++ b/test/smbjson/test_read_unshielded_multiwires_multipolar_expansion.F90
@@ -160,11 +160,11 @@ contains
       ex%mtln%networks(1)%connections(1)%nodes(1)%conductor_in_cable = 1
       ex%mtln%networks(1)%connections(1)%nodes(1)%side = TERMINAL_NODE_SIDE_INI
       ex%mtln%networks(1)%connections(1)%nodes(1)%belongs_to_cable =>  ex%mtln%cables(1)%ptr
-      ex%mtln%networks(1)%connections(1)%nodes(1)%termination%termination_type = TERMINATION_OPEN
+      ex%mtln%networks(1)%connections(1)%nodes(1)%termination%termination_type = TERMINATION_SHORT
       ex%mtln%networks(1)%connections(2)%nodes(1)%conductor_in_cable = 2
       ex%mtln%networks(1)%connections(2)%nodes(1)%side = TERMINAL_NODE_SIDE_INI
       ex%mtln%networks(1)%connections(2)%nodes(1)%belongs_to_cable =>  ex%mtln%cables(1)%ptr
-      ex%mtln%networks(1)%connections(2)%nodes(1)%termination%termination_type = TERMINATION_OPEN
+      ex%mtln%networks(1)%connections(2)%nodes(1)%termination%termination_type = TERMINATION_SHORT
 
       allocate(ex%mtln%networks(2)%connections(2))
       allocate(ex%mtln%networks(2)%connections(1)%nodes(1))
@@ -172,11 +172,11 @@ contains
       ex%mtln%networks(2)%connections(1)%nodes(1)%conductor_in_cable = 1
       ex%mtln%networks(2)%connections(1)%nodes(1)%side = TERMINAL_NODE_SIDE_END
       ex%mtln%networks(2)%connections(1)%nodes(1)%belongs_to_cable =>  ex%mtln%cables(1)%ptr
-      ex%mtln%networks(2)%connections(1)%nodes(1)%termination%termination_type = TERMINATION_OPEN
+      ex%mtln%networks(2)%connections(1)%nodes(1)%termination%termination_type = TERMINATION_SHORT
       ex%mtln%networks(2)%connections(2)%nodes(1)%conductor_in_cable = 2
       ex%mtln%networks(2)%connections(2)%nodes(1)%side = TERMINAL_NODE_SIDE_END
       ex%mtln%networks(2)%connections(2)%nodes(1)%belongs_to_cable =>  ex%mtln%cables(1)%ptr
-      ex%mtln%networks(2)%connections(2)%nodes(1)%termination%termination_type = TERMINATION_OPEN
+      ex%mtln%networks(2)%connections(2)%nodes(1)%termination%termination_type = TERMINATION_SHORT
 
 
    end function

--- a/testData/cases/coated_antenna/coated_antenna.fdtd.json
+++ b/testData/cases/coated_antenna/coated_antenna.fdtd.json
@@ -27,7 +27,7 @@
         {
             "id": 2,
             "type": "terminal",
-            "terminations": [{"type": "open"}]
+            "terminations": [{"type": "short"}]
         },
         {
             "id": 3,

--- a/testData/cases/holland/holland1981.fdtd.json
+++ b/testData/cases/holland/holland1981.fdtd.json
@@ -27,7 +27,7 @@
         {
             "id": 2,
             "type": "terminal",
-            "terminations": [{"type": "open"}]
+            "terminations": [{"type": "short"}]
         }
     ],
 

--- a/testData/cases/holland/holland1981_unshielded.fdtd.json
+++ b/testData/cases/holland/holland1981_unshielded.fdtd.json
@@ -28,7 +28,7 @@
         {
             "id": 2,
             "type": "terminal",
-            "terminations": [{"type": "open"}]
+            "terminations": [{"type": "short"}]
         }
     ],
 

--- a/testData/cases/holland_mpi/holland1981.fdtd.json
+++ b/testData/cases/holland_mpi/holland1981.fdtd.json
@@ -27,7 +27,7 @@
         {
             "id": 2,
             "type": "terminal",
-            "terminations": [{"type": "open"}]
+            "terminations": [{"type": "short"}]
         },
         {
             "id": 3,

--- a/testData/cases/lineIntegralProbe/lineIntegralProbe.fdtd.json
+++ b/testData/cases/lineIntegralProbe/lineIntegralProbe.fdtd.json
@@ -75,7 +75,7 @@
         {
             "id": 2,
             "type": "terminal",
-            "terminations": [{"type": "open"}]
+            "terminations": [{"type": "short"}]
         },
         {
             "id": 3,

--- a/testData/cases/lineIntegralProbe/lineIntegralProbe_plates.fdtd.json
+++ b/testData/cases/lineIntegralProbe/lineIntegralProbe_plates.fdtd.json
@@ -52,7 +52,7 @@
         {
             "id": 2,
             "type": "terminal",
-            "terminations": [{"type": "open"}]
+            "terminations": [{"type": "short"}]
         },
         {
             "id": 3,

--- a/testData/cases/observation/observation.fdtd.json
+++ b/testData/cases/observation/observation.fdtd.json
@@ -41,7 +41,7 @@
             "type": "terminal",
             "terminations": [
                 {
-                    "type": "open"
+                    "type": "short"
                 }
             ]
         }

--- a/testData/cases/observation/wires.fdtd.json
+++ b/testData/cases/observation/wires.fdtd.json
@@ -51,7 +51,7 @@
             "name": "terminal2",
             "id": 3,
             "type": "terminal",
-            "terminations": [ {"type": "open"} ]
+            "terminations": [ {"type": "short"} ]
         },
         {
             "name": "wireMaterial2",

--- a/testData/cases/observation/wires_collision.fdtd.json
+++ b/testData/cases/observation/wires_collision.fdtd.json
@@ -52,7 +52,7 @@
             "name": "terminal2",
             "id": 3,
             "type": "terminal",
-            "terminations": [ {"type": "open"} ]
+            "terminations": [ {"type": "short"} ]
         },
         {
             "name": "wireMaterial2",

--- a/testData/cases/observation/wires_collision_Jprobe.fdtd.json
+++ b/testData/cases/observation/wires_collision_Jprobe.fdtd.json
@@ -53,7 +53,7 @@
             "name": "terminal2",
             "id": 3,
             "type": "terminal",
-            "terminations": [ {"type": "open"} ]
+            "terminations": [ {"type": "short"} ]
         },
         {
             "name": "wireMaterial2",

--- a/testData/cases/opamp_saturation/opamp_saturation.fdtd.json
+++ b/testData/cases/opamp_saturation/opamp_saturation.fdtd.json
@@ -38,7 +38,7 @@
 			"type": "terminal",
 			"terminations" : [
 				{"type": "series", "resistance": 50, "capacitance": 1e22, "inductance" : 0.0 },
-				{"type": "open"}
+				{"type": "short"}
 			]
 		},
 		{

--- a/testData/cases/unshielded_multiwires/unshielded_multiwires_berenger.fdtd.json
+++ b/testData/cases/unshielded_multiwires/unshielded_multiwires_berenger.fdtd.json
@@ -166,10 +166,10 @@
             "type": "terminal",
             "terminations": [
                 {
-                    "type": "open"
+                    "type": "short"
                 },
                 {
-                    "type": "open"
+                    "type": "short"
                 }
             ]
         },
@@ -178,7 +178,7 @@
             "type": "terminal",
             "terminations": [
                 {
-                    "type": "open"
+                    "type": "short"
                 }
             ]
         }

--- a/testData/cases/unshielded_multiwires/unshielded_multiwires_multipolar_expansion.fdtd.json
+++ b/testData/cases/unshielded_multiwires/unshielded_multiwires_multipolar_expansion.fdtd.json
@@ -187,10 +187,10 @@
             "type": "terminal",
             "terminations": [
                 {
-                    "type": "open"
+                    "type": "short"
                 },
                 {
-                    "type": "open"
+                    "type": "short"
                 }
             ]
         }

--- a/testData/input_examples/holland1981.fdtd.json
+++ b/testData/input_examples/holland1981.fdtd.json
@@ -27,7 +27,7 @@
         {
             "id": 2,
             "type": "terminal",
-            "terminations": [{"type": "open"}]
+            "terminations": [{"type": "short"}]
         }
     ],
 

--- a/testData/input_examples/holland1981_unshielded.fdtd.json
+++ b/testData/input_examples/holland1981_unshielded.fdtd.json
@@ -28,7 +28,7 @@
         {
             "id": 2,
             "type": "terminal",
-            "terminations": [{"type": "open"}]
+            "terminations": [{"type": "short"}]
         }
     ],
 

--- a/testData/input_examples/unshielded_multiwires_berenger.fdtd.json
+++ b/testData/input_examples/unshielded_multiwires_berenger.fdtd.json
@@ -166,10 +166,10 @@
             "type": "terminal",
             "terminations": [
                 {
-                    "type": "open"
+                    "type": "short"
                 },
                 {
-                    "type": "open"
+                    "type": "short"
                 }
             ]
         },
@@ -178,7 +178,7 @@
             "type": "terminal",
             "terminations": [
                 {
-                    "type": "open"
+                    "type": "short"
                 }
             ]
         }

--- a/testData/input_examples/unshielded_multiwires_multipolar_expansion.fdtd.json
+++ b/testData/input_examples/unshielded_multiwires_multipolar_expansion.fdtd.json
@@ -107,10 +107,10 @@
             "type": "terminal",
             "terminations": [
                 {
-                    "type": "open"
+                    "type": "short"
                 },
                 {
-                    "type": "open"
+                    "type": "short"
                 }
             ]
         }


### PR DESCRIPTION
- Remove J_MAT_TERM_TYPE_OPEN label from smbjson_labels.F90
- Parser now raises an error when 'open' termination type is encountered
- Remove TERMINATION_OPEN constant from mtln_types.F90
- Remove writeOpenNode function from preprocess.F90
- Remove open field from nw_node_t in network.F90
- Remove open-terminal branch from mtln_solver.F90
- Update all test JSON data: replace 'open' terminations with 'short'
- Update unit tests: replace TERMINATION_OPEN with TERMINATION_SHORT
- Remove 'open' from fdtdjson.md documentation