### PR TITLE
Treat floating MTLN short terminals as open

### DIFF
--- a/src_mtln/preprocess.F90
+++ b/src_mtln/preprocess.F90
@@ -1171,15 +1171,23 @@ contains
         character(256), dimension(:), allocatable :: node_description, old_description
 
         type(nw_node_t) :: new_node
+        type(terminal_node_t) :: node
+
+        node = terminal_connection%nodes(1)
+        ! A short on an isolated terminal has no physical return path.
+        if (node%termination%termination_type == TERMINATION_SHORT) then
+            node%termination%termination_type = TERMINATION_OPEN
+        end if
+
         aux_nodes = nodes
         deallocate(nodes)
         allocate(nodes(size(aux_nodes) + 1))
 
-        new_node = this%addNodeWithId(terminal_connection%nodes(1))
+        new_node = this%addNodeWithId(node)
         nodes(size(aux_nodes) + 1) = new_node
         nodes(1:size(nodes) - 1) = aux_nodes
 
-        node_description = writeNodeDescription(new_node, terminal_connection%nodes(1)%termination, "0")
+        node_description = writeNodeDescription(new_node, node%termination, "0")
         old_description = description
         deallocate(description)
         allocate(description(size(old_description) + size(node_description)))

--- a/test/mtln/mtln_tests.h
+++ b/test/mtln/mtln_tests.h
@@ -43,6 +43,7 @@ extern "C" int test_preprocess_conductors_before_cable();
 extern "C" int test_preprocess_conductors_in_level();
 extern "C" int test_preprocess_zt_conductor_ranges_2();
 extern "C" int test_preprocess_zt_conductor_ranges();
+extern "C" int test_preprocess_floating_short_terminal_is_open();
 // extern "C" int test_coaxial_line_paul_8_6_square();
 // extern "C" int test_coaxial_line_paul_8_6_triangle();
 // extern "C" int test_2_conductor_line_paul_9_6();
@@ -71,6 +72,7 @@ TEST(mtln, preprocess_conductors_before_cable) { EXPECT_EQ(0, test_preprocess_co
 TEST(mtln, preprocess_conductors_in_level) { EXPECT_EQ(0, test_preprocess_conductors_in_level()); }
 TEST(mtln, preprocess_zt_conductor_ranges_2) { EXPECT_EQ(0, test_preprocess_zt_conductor_ranges_2()); }
 TEST(mtln, preprocess_zt_conductor_ranges) { EXPECT_EQ(0, test_preprocess_zt_conductor_ranges()); }
+TEST(mtln, preprocess_floating_short_terminal_is_open) { EXPECT_EQ(0, test_preprocess_floating_short_terminal_is_open()); }
 
 TEST(mtln, math_eigvals) { EXPECT_EQ(0, test_math_eigvals()); }
 TEST(mtln, math_matmul_broadcast) { EXPECT_EQ(0, test_math_matmul_broadcast()); }

--- a/test/mtln/test_preprocess.F90
+++ b/test/mtln/test_preprocess.F90
@@ -216,3 +216,84 @@ integer function test_preprocess_zt_conductor_ranges_2() bind(C) result(error_cn
 
 end function
 
+integer function test_preprocess_floating_short_terminal_is_open() bind(C) result(error_cnt)
+
+    use mtln_solver_m
+    use mtln_testingTools_mod
+    use mtln_preprocess_m
+    implicit none
+
+    type(unshielded_multiwire_t), target :: cable
+    type(terminal_node_t) :: node
+    type(terminal_connection_t) :: connection
+    type(terminal_network_t) :: network
+    type(parsed_mtln_t) :: parsed
+    type(mtln_t) :: solver
+    type(segment_t), dimension(8) :: segments
+    type(multipolar_expansion_t), allocatable, dimension(:) :: multipolar_expansion
+
+    real(kind=rkind), dimension(1,1) :: lpul = 0.25e-6
+    real(kind=rkind), dimension(1,1) :: gpul = 0.0
+    real(kind=rkind), dimension(1,1) :: rpul = 0.0
+    real(kind=rkind), dimension(1,1) :: cpul = 100.0e-12
+    integer :: i
+
+    error_cnt = 0
+
+    cable%name = "wire0"
+    cable%cell_inductance_per_meter = lpul
+    cable%cell_capacitance_per_meter = cpul
+    cable%conductance_per_meter = gpul
+    cable%resistance_per_meter = rpul
+    cable%radius = 0.0_rkind
+
+    allocate(multipolar_expansion(0))
+    cable%multipolar_expansion = multipolar_expansion
+
+    do i = 1, 8
+        segments(i)%x = i
+        segments(i)%y = 1
+        segments(i)%z = 1
+        segments(i)%orientation = DIRECTION_X_POS
+    end do
+    cable%segments = segments
+    cable%step_size = [(4.0_rkind, i = 1, 8)]
+
+    node%belongs_to_cable => cable
+    node%conductor_in_cable = 1
+    node%side = TERMINAL_NODE_SIDE_END
+    node%termination = termination_t(termination_type = TERMINATION_SHORT)
+
+    connection%nodes = [node]
+    network%connections = [connection]
+
+    parsed%time_step = 1.0e-9
+    parsed%number_of_steps = 10
+
+    allocate(parsed%networks(1))
+    parsed%networks = [network]
+
+    allocate(parsed%cables(1))
+    parsed%cables(1)%ptr => cable
+
+    allocate(parsed%probes(0))
+    allocate(parsed%wireGenerators(0))
+
+    solver = mtlnCtor(parsed)
+
+    if (size(solver%network_manager%networks) /= 1) then
+        error_cnt = error_cnt + 1
+        return
+    end if
+
+    if (size(solver%network_manager%networks(1)%nodes) /= 1) then
+        error_cnt = error_cnt + 1
+        return
+    end if
+
+    if (.not. solver%network_manager%networks(1)%nodes(1)%open) then
+        error_cnt = error_cnt + 1
+    end if
+
+end function
+


### PR DESCRIPTION
## Summary
- treat single-node MTLN terminal connections with `short` termination as `open`
- this matches Holland-style behavior for terminals without physical contact
- preserve existing behavior for connected terminals (multi-node connections)

## Implementation
- in `src_mtln/preprocess.F90`, `connectNodeToGround` now converts a local `TERMINATION_SHORT` to `TERMINATION_OPEN` before node creation and netlist generation
- this ensures the internal `open` node flag and SPICE description are consistent

## Tests
- added regression test `test_preprocess_floating_short_terminal_is_open` in `test/mtln/test_preprocess.F90`
- registered in `test/mtln/mtln_tests.h`
- verified with:
  - `cmake --build build-dbg -j`
  - `./build-dbg/bin/fdtd_tests --gtest_filter=mtln.preprocess_floating_short_terminal_is_open`

Fixes #387