### PR TITLE
Fix MTLN memory leak and per-step heap allocations

### DIFF
--- a/src_mtln/dispersive.F90
+++ b/src_mtln/dispersive.F90
@@ -76,12 +76,17 @@ contains
 
     subroutine updateQ3Phi(this)
         class(dispersive_t) :: this
-        integer :: i_div,j,k
+        integer :: i_div, i, j
 
-        this%q3_phi(:,:) = reshape(&
-            source = [(dotmatrixmul(this%q3(i_div, :, :, :), this%phi(i_div, :, :)), i_div = 1, this%number_of_divisions)], &
-            shape=[this%number_of_divisions, this%number_of_conductors], &
-            order=[2,1])
+        this%q3_phi = 0.0
+        do i_div = 1, this%number_of_divisions
+            do i = 1, this%number_of_conductors
+                do j = 1, this%number_of_conductors
+                    this%q3_phi(i_div, i) = this%q3_phi(i_div, i) + &
+                        dot_product(this%q3(i_div, i, j, :), this%phi(i_div, j, :))
+                end do
+            end do
+        end do
     end subroutine
 
     subroutine updatePhi(this, i_prev, i_now)

--- a/src_mtln/mtl_bundle.F90
+++ b/src_mtln/mtl_bundle.F90
@@ -17,7 +17,7 @@ module mtl_bundle_m
         real(kind=rkind), allocatable, dimension(:,:,:) :: lpul, cpul, rpul, gpul
         integer  :: number_of_conductors = 0, number_of_divisions = 0
         real(kind=RKIND), dimension(:), allocatable :: step_size
-        real(kind=RKIND), allocatable, dimension(:,:) :: v, i
+        real(kind=RKIND), allocatable, dimension(:,:) :: v, i, i_prev
         real(kind=RKIND), allocatable, dimension(:,:) :: v_source, i_source, e_L
         real(kind=RKIND), allocatable, dimension(:,:,:) :: du(:,:,:)
         real(kind=RKIND_TIEMPO) :: time = 0.0, dt = 1e10
@@ -115,6 +115,7 @@ contains
 
         allocate(this%v(this%number_of_conductors, this%number_of_divisions + 1), source = 0.0_rkind)
         allocate(this%i(this%number_of_conductors, this%number_of_divisions), source = 0.0_rkind)
+        allocate(this%i_prev(this%number_of_conductors, this%number_of_divisions), source = 0.0_rkind)
         allocate(this%e_L(this%number_of_conductors, this%number_of_divisions), source = 0.0_rkind)
 
         allocate(this%v_source(this%number_of_conductors, this%number_of_divisions + 1), source = 0.0_rkind)
@@ -406,7 +407,6 @@ contains
 
     subroutine bundle_advanceCurrent(this)
         class(mtl_bundle_t) ::this
-        real(kind=rkind), dimension(:,:), allocatable :: i_prev, i_now
         integer :: i
         real(kind=rkind) :: eps_r
 #ifdef CompileWithMPI
@@ -418,7 +418,7 @@ contains
         if (sizeof > 1) call this%Comm_MPI_V()
 #endif
         call this%transfer_impedance%updateQ3Phi()
-        i_prev = this%i
+        this%i_prev = this%i
 
         do i = 1, this%number_of_divisions
             this%i(:,i) = matmul(this%i_term(i,:,:), this%i(:,i)) - &
@@ -427,8 +427,7 @@ contains
                                                       matmul(this%du(i,:,:),this%v_source(:,i))) - &
                           matmul(this%v_diff(i,:,:), matmul(this%du(i,:,:), this%transfer_impedance%q3_phi(i,:)))
         enddo
-        i_now = this%i
-        call this%transfer_impedance%updatePhi(i_prev, i_now)
+        call this%transfer_impedance%updatePhi(this%i_prev, this%i)
     end subroutine
 
     subroutine bundle_setExternalLongitudinalField(this)


### PR DESCRIPTION
Fixes #392.

## Root causes

Two sources of per-time-step dynamic heap allocation were found in the MTLN hot path:

### 1. `updateQ3Phi` — allocatable function inside array constructor

`updateQ3Phi` called `dotmatrixmul` (a function returning an `allocatable` result) inside an implied-do array constructor on every time step. gfortran does not always properly release intermediate allocatables produced inside such constructors, causing RAM usage to grow progressively over the simulation.

**Fix:** replaced the array constructor pattern with an explicit nested loop that accumulates directly into `this%q3_phi`, eliminating all dynamic allocation from this routine.

### 2. `bundle_advanceCurrent` — repeated malloc/free of `i_prev`/`i_now`

`bundle_advanceCurrent` declared two local allocatable arrays (`i_prev`, `i_now`) that were automatically allocated and deallocated on every call (every FDTD time step). This contributes both to heap pressure and to the slowdown observed when MTLN is enabled.

**Fix:** added `i_prev` as a persistent pre-allocated member of `mtl_bundle_t` (allocated once in `initialAllocation`). `i_now` was eliminated entirely by passing `this%i` directly to `updatePhi`.

## Testing

All 114 unit tests pass (`./build/bin/fdtd_tests`).
