### PR TITLE
FDTD | Feature | Add Observation Output Foundations

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -6,9 +6,6 @@ on:
       - main
 
   pull_request:
-    branches:
-      - main
-      - dev
       
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -7,9 +7,6 @@ on:
       - main
 
   pull_request:
-    branches:
-      - main
-      - dev
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/src_output/domain.F90
+++ b/src_output/domain.F90
@@ -1,0 +1,67 @@
+module domain_m
+   use FDETYPES_m
+   use outputTypes_m
+   implicit none
+
+   private
+   public :: domain_t
+
+   interface domain_t
+     module procedure new_domain_time, new_domain_freq, new_domain_both, null_domain
+   end interface domain_t
+
+contains
+   function new_domain_time(tstart, tstop, tstep) result(new_domain)
+      real(kind=RKIND_tiempo), intent(in) :: tstart, tstop, tstep
+      type(domain_t) :: new_domain
+
+      new_domain%tstart = tstart
+      new_domain%tstop = tstop
+      new_domain%tstep = tstep
+      new_domain%domainType = TIME_DOMAIN
+   end function new_domain_time
+
+   function new_domain_freq(fstart, fstop, fnum, logarithmicSpacing) result(new_domain)
+      real(kind=RKIND), intent(in)     :: fstart, fstop
+      integer(kind=SINGLE), intent(in) :: fnum
+      logical, intent(in)    :: logarithmicSpacing
+      type(domain_t) :: new_domain
+
+      new_domain%fstart = fstart
+      new_domain%fstop = fstop
+      new_domain%fnum = fnum
+      new_domain%fstep = (fstop - fstart) / fnum
+      new_domain%logarithmicSpacing = logarithmicSpacing
+
+      new_domain%domainType = FREQUENCY_DOMAIN
+
+
+   end function new_domain_freq
+
+   function new_domain_both(tstart, tstop, tstep, fstart, fstop, fnum, logarithmicSpacing) result(new_domain)
+      real(kind=RKIND_tiempo), intent(in) :: tstart, tstop, tstep
+      real(kind=RKIND), intent(in)     :: fstart, fstop
+      integer(kind=SINGLE), intent(in) :: fnum
+      logical, intent(in)   :: logarithmicSpacing
+      type(domain_t) :: new_domain
+
+      new_domain%tstart = tstart
+      new_domain%tstop = tstop
+      new_domain%tstep = tstep
+
+      new_domain%fstart = fstart
+      new_domain%fstop = fstop
+      new_domain%fnum = fnum
+      new_domain%fstep = (fstop - fstart) / fnum
+      new_domain%logarithmicSpacing = logarithmicSpacing
+
+      new_domain%domainType = BOTH_DOMAIN
+
+   end function new_domain_both
+
+   function null_domain() result(new_domain)
+      type(domain_t) :: new_domain
+      new_domain%domainType = UNDEFINED_DOMAIN
+   end function
+
+end module domain_m

--- a/src_output/outputTypes.F90
+++ b/src_output/outputTypes.F90
@@ -1,0 +1,221 @@
+module outputTypes_m
+   use FDETYPES_m
+   use HollandWires_m
+   use wiresHolland_constants_m
+#ifdef CompileWithBerengerWires
+   use WiresBerenger
+#endif
+#ifdef CompileWithSlantedWires
+   use WiresSlanted
+   use WiresSlanted_Types
+   use WiresSlanted_Constants
+#endif
+   implicit none
+
+!=====================================================
+! Parameters & constants
+!=====================================================
+   integer, parameter :: UNDEFINED_DOMAIN  = -1
+   integer, parameter :: TIME_DOMAIN       =  0
+   integer, parameter :: FREQUENCY_DOMAIN  =  1
+   integer, parameter :: BOTH_DOMAIN       =  2
+
+
+   character(len=4), parameter :: binaryExtension = '.bin'
+   character(len=4), parameter :: pvdExtension = '.pvd'
+   character(len=4), parameter :: datFileExtension = '.dat'
+   character(len=4), parameter :: vtkFileExtension = '.vtk'
+   character(len=4), parameter :: vtuFileExtension = '.vtu'
+   character(len=2), parameter :: timeExtension    = 'tm'
+   character(len=2), parameter :: frequencyExtension = 'fq'
+   character(len=1), parameter :: wordseparation = '_'
+
+!=====================================================
+! Basic helper / geometry types
+!=====================================================
+   type :: cell_coordinate_t
+      integer(kind=SINGLE) :: x, y, z
+   end type cell_coordinate_t
+
+   type :: domain_t
+      real(kind=RKIND_tiempo) :: tstart = 0.0_RKIND_tiempo
+      real(kind=RKIND_tiempo) :: tstop  = 0.0_RKIND_tiempo
+      real(kind=RKIND_tiempo) :: tstep  = 0.0_RKIND_tiempo
+      real(kind=RKIND)        :: fstart = 0.0_RKIND
+      real(kind=RKIND)        :: fstop  = 0.0_RKIND
+      real(kind=RKIND)        :: fstep
+      integer(kind=SINGLE)    :: fnum = 0
+      integer(kind=SINGLE)    :: domainType = UNDEFINED_DOMAIN
+      logical                 :: logarithmicSpacing = .false.
+   end type domain_t
+
+   type :: spheric_domain_t
+      real(kind=RKIND) :: phiStart   = 0.0_RKIND
+      real(kind=RKIND) :: phiStop    = 0.0_RKIND
+      real(kind=RKIND) :: phiStep    = 0.0_RKIND
+      real(kind=RKIND) :: thetaStart = 0.0_RKIND
+      real(kind=RKIND) :: thetaStop  = 0.0_RKIND
+      real(kind=RKIND) :: thetastep  = 0.0_RKIND
+   end type spheric_domain_t
+
+!=====================================================
+! Field & current data containers
+!=====================================================
+   type :: field_data_t
+      real(kind=RKIND), pointer, dimension(:, :, :), contiguous :: x => NULL()
+      real(kind=RKIND), pointer, dimension(:, :, :), contiguous :: y => NULL()
+      real(kind=RKIND), pointer, dimension(:, :, :), contiguous :: z => NULL()
+      real(kind=RKIND), pointer, dimension(:), contiguous :: deltaX => NULL()
+      real(kind=RKIND), pointer, dimension(:), contiguous :: deltaY => NULL()
+      real(kind=RKIND), pointer, dimension(:), contiguous :: deltaZ => NULL()
+   end type field_data_t
+
+   type :: fields_reference_t
+      type(field_data_t) :: E
+      type(field_data_t) :: H
+   end type fields_reference_t
+
+   type :: current_values_t
+      real(kind=RKIND) :: current = 0.0_RKIND
+      real(kind=RKIND) :: deltaVoltage = 0.0_RKIND
+      real(kind=RKIND) :: plusVoltage  = 0.0_RKIND
+      real(kind=RKIND) :: minusVoltage = 0.0_RKIND
+      real(kind=RKIND) :: voltageDiference = 0.0_RKIND
+   end type current_values_t
+
+!=====================================================
+! Abstract probe hierarchy
+!=====================================================
+   type :: abstract_probe_t
+      integer(kind=SINGLE)      :: columnas
+      type(domain_t)            :: domain
+      type(cell_coordinate_t)   :: mainCoords
+      integer(kind=SINGLE)      :: component
+      character(len=BUFSIZE)    :: path
+   end type abstract_probe_t
+   type, extends(abstract_probe_t) :: abstract_time_probe_t
+      character(len=BUFSIZE) :: filePathTime
+      integer(kind=SINGLE) :: nTime = 0_SINGLE
+      integer(kind=SINGLE) :: nTimesFlushed = 0_SINGLE !times alredy writen in disk
+      real(kind=RKIND_tiempo), allocatable :: timeStep(:)
+   end type abstract_time_probe_t
+
+   type, extends(abstract_probe_t) :: abstract_frequency_probe_t
+      character(len=BUFSIZE) :: filePathFreq
+      integer(kind=SINGLE) :: nFreq = 0_SINGLE
+      real(kind=RKIND), allocatable    :: frequencySlice(:)
+      complex(kind=CKIND), allocatable :: auxExp_E(:), auxExp_H(:)
+   end type abstract_frequency_probe_t
+
+   type, extends(abstract_probe_t) :: abstract_time_frequency_probe_t
+      character(len=BUFSIZE) :: filePathTime, filePathFreq
+      integer(kind=SINGLE) :: nTime = 0_SINGLE, nFreq = 0_SINGLE
+      real(kind=RKIND_tiempo), allocatable :: timeStep(:)
+      real(kind=RKIND), allocatable        :: frequencySlice(:)
+      complex(kind=CKIND), allocatable     :: auxExp_E(:), auxExp_H(:)
+   end type abstract_time_frequency_probe_t
+
+!=====================================================
+! Concrete probe types
+!=====================================================
+
+   type, extends(abstract_probe_t) :: mapvtk_output_t
+      type(cell_coordinate_t) :: auxCoords
+      integer(kind=SINGLE), allocatable :: coords(:, :)
+      integer(kind=SINGLE), allocatable :: currentType(:)
+      integer(kind=SINGLE), allocatable :: materialTag(:)
+      integer :: nPoints = -1
+   end type mapvtk_output_t
+
+   type, extends(abstract_time_frequency_probe_t) :: point_probe_output_t
+      real(kind=RKIND), allocatable :: valueForTime(:)
+      complex(kind=CKIND), allocatable :: valueForFreq(:)
+   end type point_probe_output_t
+
+   type, extends(abstract_time_probe_t) :: wire_charge_probe_output_t
+      integer(kind=SINGLE) :: sign = +1
+      real(kind=RKIND), allocatable :: chargeValue(:)
+      type(CurrentSegments_t), pointer :: segment
+   end type wire_charge_probe_output_t
+
+   type, extends(abstract_time_probe_t) :: wire_current_probe_output_t
+      integer(kind=SINGLE) :: sign = +1
+      type(current_values_t) :: currentValues(BuffObse)
+      type(CurrentSegments_t), pointer :: segment
+#ifdef CompileWithBerengerWires
+      type(TSegment), pointer :: segmentBerenger
+#endif
+#ifdef CompileWithSlantedWires
+      class(Segment), pointer :: segmentSlanted
+#endif
+   end type wire_current_probe_output_t
+
+   type, extends(abstract_time_probe_t) :: bulk_current_probe_output_t
+      !Binary format: timeStamp, Val. Total register size: 16
+      type(cell_coordinate_t) :: auxCoords
+      real(kind=RKIND), allocatable :: valueForTime(:)
+   end type bulk_current_probe_output_t
+
+   type, extends(abstract_frequency_probe_t) :: far_field_probe_output_t
+      type(spheric_domain_t)  :: sphericRange
+      type(cell_coordinate_t) :: auxCoords
+      integer(kind=SINGLE)    :: nPoints = -1
+      integer(kind=SINGLE), allocatable :: coords(:, :)
+      complex(kind=CKIND), allocatable :: valueForFreq(:, :)
+   end type far_field_probe_output_t
+
+   type, extends(abstract_time_probe_t) :: movie_probe_output_t
+      !Binary format: timeStamp, x, y, z, xVal, yVal, zVal. Total register size: 44
+      type(cell_coordinate_t) :: auxCoords
+      integer(kind=SINGLE)    :: nPoints = -1
+      integer(kind=SINGLE), allocatable :: coords(:, :)     !(3, coordIdx)
+      real(kind=RKIND), allocatable :: xValueForTime(:, :)  !(time, coordIdx)
+      real(kind=RKIND), allocatable :: yValueForTime(:, :)  !(time, coordIdx)
+      real(kind=RKIND), allocatable :: zValueForTime(:, :)  !(time, coordIdx)
+      character(len=BUFSIZE) :: filesPath
+   end type movie_probe_output_t
+
+   type, extends(abstract_frequency_probe_t) :: frequency_slice_probe_output_t
+      !Binary format: frequencySlice, x, y, z, xVal, yVal, zVal. Total register size: 44
+      type(cell_coordinate_t) :: auxCoords
+      integer(kind=SINGLE)    :: nPoints = -1
+      integer(kind=SINGLE), allocatable :: coords(:, :)        !(3, coordIdx)
+      complex(kind=CKIND), allocatable :: xValueForFreq(:, :)  !(time, coordIdx)
+      complex(kind=CKIND), allocatable :: yValueForFreq(:, :)  !(time, coordIdx)
+      complex(kind=CKIND), allocatable :: zValueForFreq(:, :)  !(time, coordIdx)
+      character(len=BUFSIZE) :: filesPath
+   end type frequency_slice_probe_output_t
+
+!=====================================================
+! High-level aggregation types
+!=====================================================
+   type :: solver_output_t
+      integer(kind=SINGLE) :: outputID = -1
+      type(point_probe_output_t), allocatable :: pointProbe
+      type(wire_current_probe_output_t), allocatable :: wireCurrentProbe
+      type(wire_charge_probe_output_t), allocatable  :: wireChargeProbe
+      type(bulk_current_probe_output_t), allocatable :: bulkCurrentProbe
+      type(movie_probe_output_t), allocatable         :: movieProbe
+      type(frequency_slice_probe_output_t), allocatable :: frequencySliceProbe
+      type(far_field_probe_output_t), allocatable     :: farFieldOutput
+      type(mapvtk_output_t), allocatable              :: mapvtkOutput
+#ifdef CompileWithMPI
+      integer(kind=4) :: MPISubcomm, MPIRoot, MPIGroupIndex
+      integer(kind=4) :: ZIorig, ZEorig
+#endif
+   end type solver_output_t
+
+   type :: problem_info_t
+      type(media_matrices_t), pointer :: geometryToMaterialData
+      type(limit_t), pointer :: problemDimension(:)
+      type(bounds_t), pointer :: simulationBounds
+      type(MediaData_t), pointer :: materialList(:)
+      type(taglist_t), pointer :: materialTag
+      real(RKIND), pointer, dimension(:) :: xSteps
+      real(RKIND), pointer, dimension(:) :: ySteps
+      real(RKIND), pointer, dimension(:) :: zSteps
+   end type problem_info_t
+
+contains
+
+end module outputTypes_m

--- a/src_output/outputUtils.F90
+++ b/src_output/outputUtils.F90
@@ -1,0 +1,675 @@
+module outputUtils_m
+   use FDETYPES_m
+   use outputTypes_m
+   use domain_m
+   use report_m
+   implicit none
+   integer(kind=SINGLE), parameter :: FILE_UNIT = 400
+
+   private
+
+   !===========================
+   !  Public interface summary
+   !===========================
+   public :: new_cell_coordinate
+   public :: get_coordinates_extension
+   public :: get_prefix_extension
+   public :: get_field_component
+   public :: get_field_reference
+   public :: init_frequency_slice
+   public :: getBlockCurrentDirection
+   public :: isPEC
+   public :: isPML
+   public :: isSplitOrAdvanced
+   public :: isThinWire
+   public :: isMediaVacuum
+   public :: isWithinBounds
+   public :: isSurface
+   public :: isFlush
+   public :: computej
+   public :: computeJ1
+   public :: computeJ2
+   public :: fieldo
+   public :: create_data_file
+   public :: currentType
+   public :: get_media_from_coord_and_h_neighbours
+   !===========================
+
+   !===========================
+   !  Private interface summary
+   !===========================
+   private :: get_rotated_prefix
+   private :: prefix
+   private :: get_probe_coords_extension
+   private :: get_probe_bounds_coords_extension
+   private :: get_delta
+   !===========================
+
+   interface get_coordinates_extension
+      module procedure get_probe_coords_extension, get_probe_bounds_coords_extension
+   end interface get_coordinates_extension
+
+contains
+   function new_cell_coordinate(x, y, z) result(cell)
+      integer(kind=SINGLE), intent(in) :: x, y, z
+      type(cell_coordinate_t) :: cell
+
+      cell%x = x
+      cell%y = y
+      cell%z = z
+   end function new_cell_coordinate
+
+   function getMediaIndex(field, i, j, k, CoordToMaterial) result(res)
+      integer, intent(in) :: field, i, j, k
+      type(media_matrices_t), pointer, intent(in) :: CoordToMaterial
+
+      integer :: res
+
+      select case (field)
+      case (iEx); res = CoordToMaterial%sggMiEx(i, j, k)
+      case (iEy); res = CoordToMaterial%sggMiEy(i, j, k)
+      case (iEz); res = CoordToMaterial%sggMiEz(i, j, k)
+      case (iHx); res = CoordToMaterial%sggMiHx(i, j, k)
+      case (iHy); res = CoordToMaterial%sggMiHy(i, j, k)
+      case (iHz); res = CoordToMaterial%sggMiHz(i, j, k)
+      end select
+
+   end function
+
+   subroutine get_media_from_coord_and_h_neighbours(field, i, j, k, CoordToMaterial, media, firstPositiveMedia, firstNegativeMedia, secondPositiveMedia, secondNegativeMedia)
+      !Returns field media and Hmedia from borders of i,j,k
+      type(media_matrices_t), pointer, intent(in) :: CoordToMaterial
+      integer(4), intent(in) :: field, i, j, k
+      integer(4), intent(out) :: media, firstPositiveMedia, firstNegativeMedia, secondPositiveMedia, secondNegativeMedia
+      integer, parameter :: nFields = 3
+
+      ! Precomputed shifts for first direction
+      integer, dimension(nFields) :: shift_i = [0, -1, 0]
+      integer, dimension(nFields) :: shift_j = [0, 0, -1]
+      integer, dimension(nFields) :: shift_k = [-1, 0, 0]
+
+      ! Precomputed shifts for second direction
+      integer, dimension(nFields) :: shift_i2 = [0, 0, -1]
+      integer, dimension(nFields) :: shift_j2 = [-1, 0, 0]
+      integer, dimension(nFields) :: shift_k2 = [0, -1, 0]
+
+      ! Precomputed neighbor hfield types
+      integer, dimension(nFields) :: HFieldTable = [iHy, iHz, iHx]  ! returns perpendicular field tags from H
+
+      ! Main mediua
+      media = getMediaIndex(field, i, j, k, CoordToMaterial)
+
+      ! Neighboring media
+      !First Direction
+      firstPositiveMedia = getMediaIndex(HFieldTable(field), i, j, k, CoordToMaterial)
+      firstNegativeMedia = getMediaIndex(HFieldTable(field), i + shift_i(field), j + shift_j(field), k + shift_k(field), CoordToMaterial)
+
+      !Second Direction
+      secondPositiveMedia = getMediaIndex(HFieldTable(mod(field, nFields) + 1), i, j, k, CoordToMaterial)
+      secondNegativeMedia = getMediaIndex(HFieldTable(mod(field, nFields) + 1), i + shift_i2(field), j + shift_j2(field), k + shift_k2(field), CoordToMaterial)
+   end subroutine
+
+   function get_probe_coords_extension(coordinates, mpidir) result(ext)
+      type(cell_coordinate_t) :: coordinates
+      integer(kind=SINGLE), intent(in) ::  mpidir
+      character(len=BUFSIZE) :: ext
+      character(len=BUFSIZE)  ::  chari, charj, chark
+
+      write (chari, '(i7)') coordinates%x
+      write (charj, '(i7)') coordinates%y
+      write (chark, '(i7)') coordinates%z
+
+#if CompileWithMPI
+      if (mpidir == 3) then
+         ext = trim(adjustl(chari))//'_'//trim(adjustl(charj))//'_'//trim(adjustl(chark))
+      elseif (mpidir == 2) then
+         ext = trim(adjustl(charj))//'_'//trim(adjustl(chark))//'_'//trim(adjustl(chari))
+      elseif (mpidir == 1) then
+         ext = trim(adjustl(chark))//'_'//trim(adjustl(chari))//'_'//trim(adjustl(charj))
+      else
+         call stoponerror(0, 0, 'Buggy error in mpidir. ')
+      end if
+#else
+      ext = trim(adjustl(chari))//'_'//trim(adjustl(charj))//'_'//trim(adjustl(chark))
+#endif
+
+      return
+   end function get_probe_coords_extension
+
+   function get_probe_bounds_coords_extension(lowerCoordinates, upperCoordinates, mpidir) result(ext)
+      type(cell_coordinate_t) :: lowerCoordinates, upperCoordinates
+      integer(kind=SINGLE), intent(in) :: mpidir
+      character(len=BUFSIZE) :: ext
+      character(len=BUFSIZE)  ::  chari, charj, chark, chari2, charj2, chark2
+
+      write (chari, '(i7)') lowerCoordinates%x
+      write (charj, '(i7)') lowerCoordinates%y
+      write (chark, '(i7)') lowerCoordinates%z
+
+      write (chari2, '(i7)') upperCoordinates%x
+      write (charj2, '(i7)') upperCoordinates%y
+      write (chark2, '(i7)') upperCoordinates%z
+
+#if CompileWithMPI
+      if (mpidir == 3) then
+         ext = trim(adjustl(chari))//'_'//trim(adjustl(charj))//'_'//trim(adjustl(chark))//'__'// &
+               trim(adjustl(chari2))//'_'//trim(adjustl(charj2))//'_'//trim(adjustl(chark2))
+      elseif (mpidir == 2) then
+         ext = trim(adjustl(charj))//'_'//trim(adjustl(chark))//'_'//trim(adjustl(chari))//'__'// &
+               trim(adjustl(charj2))//'_'//trim(adjustl(chark2))//'_'//trim(adjustl(chari2))
+      elseif (mpidir == 1) then
+         ext = trim(adjustl(chark))//'_'//trim(adjustl(chari))//'_'//trim(adjustl(charj))//'__'// &
+               trim(adjustl(chark2))//'_'//trim(adjustl(chari2))//'_'//trim(adjustl(charj2))
+      else
+         call stoponerror(0, 0, 'Buggy error in mpidir. ')
+      end if
+#else
+      ext = trim(adjustl(chari))//'_'//trim(adjustl(charj))//'_'//trim(adjustl(chark))//'__'// &
+            trim(adjustl(chari2))//'_'//trim(adjustl(charj2))//'_'//trim(adjustl(chark2))
+#endif
+
+      return
+   end function get_probe_bounds_coords_extension
+
+   function get_prefix_extension(field, mpidir) result(prefixExtension)
+      integer(kind=SINGLE), intent(in)  ::  field, mpidir
+      character(len=BUFSIZE)  ::  prefixExtension
+
+#if CompileWithMPI
+      prefixExtension = get_rotated_prefix(field, mpidir)
+#else
+      prefixExtension = prefix(field)
+#endif
+   end function get_prefix_extension
+
+   function get_rotated_prefix(field, mpidir) result(prefixExtension)
+      integer(kind=SINGLE), intent(in)  ::  field, mpidir
+      character(len=BUFSIZE)  ::  prefixExtension
+      if (mpidir == 3) then
+         select case (field)
+         case (iEx); prefixExtension = prefix(iEx)
+         case (iEy); prefixExtension = prefix(iEy)
+         case (iEz); prefixExtension = prefix(iEz)
+         case (iJx); prefixExtension = prefix(iJx)
+         case (iJy); prefixExtension = prefix(iJy)
+         case (iJz); prefixExtension = prefix(iJz)
+         case (iQx); prefixExtension = prefix(iQx)
+         case (iQy); prefixExtension = prefix(iQy)
+         case (iQz); prefixExtension = prefix(iQz)
+         case (iVx); prefixExtension = prefix(iVx)
+         case (iVy); prefixExtension = prefix(iVy)
+         case (iVz); prefixExtension = prefix(iVz)
+         case (iHx); prefixExtension = prefix(iHx)
+         case (iHy); prefixExtension = prefix(iHy)
+         case (iHz); prefixExtension = prefix(iHz)
+         case (iBloqueJx); prefixExtension = prefix(iBloqueJx)
+         case (iBloqueJy); prefixExtension = prefix(iBloqueJy)
+         case (iBloqueJz); prefixExtension = prefix(iBloqueJz)
+         case (iBloqueMx); prefixExtension = prefix(iBloqueMx)
+         case (iBloqueMy); prefixExtension = prefix(iBloqueMy)
+         case (iBloqueMz); prefixExtension = prefix(iBloqueMz)
+         case default; prefixExtension = prefix(field)
+         end select
+      elseif (mpidir == 2) then
+         select case (field)
+         case (iEx); prefixExtension = prefix(iEz)
+         case (iEy); prefixExtension = prefix(iEx)
+         case (iEz); prefixExtension = prefix(iEy)
+         case (iJx); prefixExtension = prefix(iJz)
+         case (iJy); prefixExtension = prefix(iJx)
+         case (iJz); prefixExtension = prefix(iJy)
+         case (iQx); prefixExtension = prefix(iQz)
+         case (iQy); prefixExtension = prefix(iQx)
+         case (iQz); prefixExtension = prefix(iQy)
+         case (iVx); prefixExtension = prefix(iVz)
+         case (iVy); prefixExtension = prefix(iVx)
+         case (iVz); prefixExtension = prefix(iVy)
+         case (iHx); prefixExtension = prefix(iHz)
+         case (iHy); prefixExtension = prefix(iHx)
+         case (iHz); prefixExtension = prefix(iHy)
+         case (iBloqueJx); prefixExtension = prefix(iBloqueJz)
+         case (iBloqueJy); prefixExtension = prefix(iBloqueJx)
+         case (iBloqueJz); prefixExtension = prefix(iBloqueJy)
+         case (iBloqueMx); prefixExtension = prefix(iBloqueMz)
+         case (iBloqueMy); prefixExtension = prefix(iBloqueMx)
+         case (iBloqueMz); prefixExtension = prefix(iBloqueMy)
+         case default; prefixExtension = prefix(field)
+         end select
+      elseif (mpidir == 1) then
+         select case (field)
+         case (iEx); prefixExtension = prefix(iEy)
+         case (iEy); prefixExtension = prefix(iEz)
+         case (iEz); prefixExtension = prefix(iEx)
+         case (iJx); prefixExtension = prefix(iJy)
+         case (iJy); prefixExtension = prefix(iJz)
+         case (iJz); prefixExtension = prefix(iJx)
+         case (iQx); prefixExtension = prefix(iQy)
+         case (iQy); prefixExtension = prefix(iQz)
+         case (iQz); prefixExtension = prefix(iQx)
+         case (iVx); prefixExtension = prefix(iVy)
+         case (iVy); prefixExtension = prefix(iVz)
+         case (iVz); prefixExtension = prefix(iVx)
+         case (iHx); prefixExtension = prefix(iHy)
+         case (iHy); prefixExtension = prefix(iHz)
+         case (iHz); prefixExtension = prefix(iHx)
+         case (iBloqueJx); prefixExtension = prefix(iBloqueJy)
+         case (iBloqueJy); prefixExtension = prefix(iBloqueJz)
+         case (iBloqueJz); prefixExtension = prefix(iBloqueJx)
+         case (iBloqueMx); prefixExtension = prefix(iBloqueMy)
+         case (iBloqueMy); prefixExtension = prefix(iBloqueMz)
+         case (iBloqueMz); prefixExtension = prefix(iBloqueMx)
+         case default; prefixExtension = prefix(field)
+         end select
+      else
+         call stoponerror(0, 0, "Buggy error in mpidir.")
+      end if
+      return
+   end function get_rotated_prefix
+
+   function prefix(campo) result(ext)
+      integer(kind=SINGLE), intent(in)  ::  campo
+      character(len=BUFSIZE)  ::  ext
+
+      select case (campo)
+      case (iEx); ext = 'Ex'
+      case (iEy); ext = 'Ey'
+      case (iEz); ext = 'Ez'
+      case (iVx); ext = 'Vx'
+      case (iVy); ext = 'Vy'
+      case (iVz); ext = 'Vz'
+      case (iHx); ext = 'Hx'
+      case (iHy); ext = 'Hy'
+      case (iHz); ext = 'Hz'
+      case (iBloqueJx); ext = 'Jx'
+      case (iBloqueJy); ext = 'Jy'
+      case (iBloqueJz); ext = 'Jz'
+      case (iBloqueMx); ext = 'Mx'
+      case (iBloqueMy); ext = 'My'
+      case (iBloqueMz); ext = 'Mz'
+      case (iJx); ext = 'Wx'
+      case (iJy); ext = 'Wy'
+      case (iJz); ext = 'Wz'
+      case (iQx); ext = 'Qx'
+      case (iQy); ext = 'Qy'
+      case (iQz); ext = 'Qz'
+      case (iExC); ext = 'ExC'
+      case (iEyC); ext = 'EyC'
+      case (iEzC); ext = 'EzC'
+      case (iHxC); ext = 'HxC'
+      case (iHyC); ext = 'HyC'
+      case (iHzC); ext = 'HzC'
+      case (iMEC); ext = 'ME'
+      case (iMHC); ext = 'MH'
+      case (iCur); ext = 'BC'
+      case (mapvtk); ext = 'MAP'
+      case (iCurX); ext = 'BCX'
+      case (iCurY); ext = 'BCY'
+      case (iCurZ); ext = 'BCZ'
+      case (farfield); ext = 'FF'
+      case (lineIntegral); ext = 'LI'
+      end select
+      return
+   end function prefix
+
+   function fieldo(field, dir) result(fieldo2)
+      integer  ::  fieldo2, field
+      character(len=1) :: dir
+      fieldo2 = -1
+      select case (field)
+      case (iEx, iEy, iEz, iHx, iHy, iHz); fieldo2 = field
+      case (iJx, iVx, iBloqueJx, iExC, iQx); fieldo2 = iEx
+      case (iJy, iVy, iBloqueJy, iEyC, iQy); fieldo2 = iEy
+      case (iJz, iVz, iBloqueJz, iEzC, iQz); fieldo2 = iEz
+      case (iBloqueMx, iHxC); fieldo2 = iHx
+      case (iBloqueMy, iHyC); fieldo2 = iHy
+      case (iBloqueMz, iHzC); fieldo2 = iHz
+      case (iMEC)
+         select case (dir)
+         CASE ('X', 'x'); fieldo2 = iEx
+         CASE ('Y', 'y'); fieldo2 = iEY
+         CASE ('Z', 'z'); fieldo2 = iEz
+         END SELECT
+      case (iMHC)
+         select case (dir)
+         CASE ('X', 'x'); fieldo2 = ihx
+         CASE ('Y', 'y'); fieldo2 = iHY
+         CASE ('Z', 'z'); fieldo2 = iHz
+         END SELECT
+      case (iCur, iCurX, icurY, icurZ, mapvtk)  !los pongo en efield para evitar problemas con el MPI
+         select case (dir)
+         CASE ('X', 'x'); fieldo2 = iEx
+         CASE ('Y', 'y'); fieldo2 = iEY
+         CASE ('Z', 'z'); fieldo2 = iEz
+         END SELECT
+      end select
+   end function
+
+   function get_field_component(fieldId, fieldReference) result(component)
+      type(fields_reference_t), intent(in) :: fieldReference
+      integer(kind=SINGLE), intent(in) :: fieldId
+      real(kind=RKIND), pointer, dimension(:, :, :) :: component
+      select case (fieldId)
+      case (iEx); component => fieldReference%E%x
+      case (iEy); component => fieldReference%E%y
+      case (iEz); component => fieldReference%E%z
+      case (iHx); component => fieldReference%H%x
+      case (iHy); component => fieldReference%H%y
+      case (iHz); component => fieldReference%H%z
+      end select
+   end function
+
+   function get_field_reference(fieldId, fieldReference) result(field)
+      type(fields_reference_t), intent(in) :: fieldReference
+      integer(kind=SINGLE), intent(in) :: fieldId
+      type(field_data_t) :: field
+      select case (fieldId)
+      case (iBloqueJx, iBloqueJy, iBloqueJz)
+         field%x => fieldReference%E%x
+         field%y => fieldReference%E%y
+         field%z => fieldReference%E%z
+
+         field%deltaX => fieldReference%E%deltax
+         field%deltaY => fieldReference%E%deltay
+         field%deltaZ => fieldReference%E%deltaz
+      case (iBloqueMx, iBloqueMy, iBloqueMz)
+         field%x => fieldReference%H%x
+         field%y => fieldReference%H%y
+         field%z => fieldReference%H%z
+
+         field%deltaX => fieldReference%H%deltax
+         field%deltaY => fieldReference%H%deltay
+         field%deltaZ => fieldReference%H%deltaz
+      end select
+   end function get_field_reference
+
+   subroutine init_frequency_slice(frequencySlice, domain)
+      real(kind=RKIND), dimension(:), intent(out) :: frequencySlice
+      type(domain_t), intent(in) :: domain
+
+      integer(kind=SINGLE) :: i
+
+      if (domain%logarithmicSpacing) then
+         do i = 1, domain%fnum
+            frequencySlice(i) = 10.0_RKIND**(domain%fstart + (i - 1)*domain%fstep)
+         end do
+      else
+         do i = 1, domain%fnum
+            frequencySlice(i) = domain%fstart + (i - 1)*domain%fstep
+         end do
+      end if
+   end subroutine init_frequency_slice
+
+   integer function getBlockCurrentDirection(field)
+      integer(kind=4) :: field
+      select case (field)
+      case (iHx); getBlockCurrentDirection = iCurX
+      case (iHy); getBlockCurrentDirection = iCurY
+      case (iHz); getBlockCurrentDirection = iCurZ
+      case default; call StopOnError(0, 0, 'field is not H field')
+      end select
+   end function
+
+   logical function isThinWire(field, i, j, k, problem)
+      integer(kind=4), intent(in) :: field, i, j, k
+      type(problem_info_t), intent(in) :: problem
+
+      integer(kind=SINGLE) :: mediaIndex
+
+      mediaIndex = getMediaIndex(field, i, j, k, problem%geometryToMaterialData)
+      isThinWire = problem%materialList(mediaIndex)%is%ThinWire
+   end function
+
+   logical function isPEC(field, i, j, k, problem)
+      integer(kind=4), intent(in) :: field, i, j, k
+      type(problem_info_t), intent(in) :: problem
+
+      integer(kind=SINGLE) :: mediaIndex
+
+      mediaIndex = getMediaIndex(field, i, j, k, problem%geometryToMaterialData)
+      isPEC = problem%materialList(mediaIndex)%is%PEC
+   end function
+
+   logical function isPML(field, i, j, k, problem)
+      integer(kind=4) :: field, i, j, k
+      integer(kind=SINGLE) :: mediaIndex
+      type(problem_info_t), intent(in) :: problem
+      mediaIndex = getMediaIndex(field, i, j, k, problem%geometryToMaterialData)
+      isPML = problem%materialList(mediaIndex)%is%PML
+   end function
+
+   logical function isSurface(field, i, j, k, problem)
+      integer(kind=4), intent(in) :: field, i, j, k
+      type(problem_info_t), intent(in) :: problem
+
+      integer(kind=SINGLE) :: mediaIndex
+
+      mediaIndex = getMediaIndex(field, i, j, k, problem%geometryToMaterialData)
+      isSurface = problem%materialList(mediaIndex)%is%Surface
+   end function
+
+   logical function isWithinBounds(field, i, j, k, problem)
+      integer(kind=4), intent(in) :: field, i, j, k
+      type(problem_info_t), intent(in) :: problem
+
+      isWithinBounds = (i <= problem%problemDimension(field)%XE) .and. &
+                       (j <= problem%problemDimension(field)%YE) .and. &
+                       (k <= problem%problemDimension(field)%ZE) .and. &
+                       (i >= problem%problemDimension(field)%XI) .and. &
+                       (j >= problem%problemDimension(field)%YI) .and. &
+                       (k >= problem%problemDimension(field)%ZI)
+   end function
+
+   logical function isMediaVacuum(field, i, j, k, problem)
+      integer(kind=4), intent(in) :: field, i, j, k
+      type(problem_info_t), intent(in) :: problem
+
+      integer(kind=INTEGERSIZEOFMEDIAMATRICES) :: mediaIndex
+      integer(kind=INTEGERSIZEOFMEDIAMATRICES), parameter :: vacuum = 1
+
+      mediaIndex = getMediaIndex(field, i, j, k, problem%geometryToMaterialData)
+      isMediaVacuum = (mediaIndex == vacuum)
+   end function
+
+   logical function isSplitOrAdvanced(field, i, j, k, problem)
+      integer(kind=4), intent(in) :: field, i, j, k
+      type(problem_info_t), intent(in) :: problem
+
+      integer(kind=INTEGERSIZEOFMEDIAMATRICES) :: mediaIndex
+      mediaIndex = getMediaIndex(field, i, j, k, problem%geometryToMaterialData)
+
+      isSplitOrAdvanced = problem%materialList(mediaIndex)%is%split_and_useless .or. &
+                          problem%materialList(mediaIndex)%is%already_YEEadvanced_byconformal
+   end function
+
+   function computej(field, i, j, k, fields_reference) result(res)
+      implicit none
+
+      ! Input Arguments
+      integer(kind=single), intent(in) :: field, i, j, k
+      type(fields_reference_t), intent(in) :: fields_reference
+
+      ! Local Variables
+      integer(kind=single) :: i_shift_a, j_shift_a, k_shift_a  ! Shift for Term A (Offset for H/M field)
+      integer(kind=single) :: i_shift_b, j_shift_b, k_shift_b  ! Shift for Term B (Offset for H/M field)
+
+      integer(kind=single) :: curl_component_a                 ! H/M field component for Term A
+      integer(kind=single) :: curl_component_b                 ! H/M field component for Term B
+
+      real(kind=rkind) :: res
+
+      ! -----------------------------------------------------------
+      ! 1. Determine Curl Components
+      !    The MOD 3 operation cyclically maps the E-field to the two required H-field components.
+      ! -----------------------------------------------------------
+
+      ! Component A (The 'next' component in the sequence)
+      curl_component_a = 1 + mod(field + 1, 3)
+
+      ! Component B (The 'current' component in the sequence)
+      curl_component_b = 1 + mod(field, 3)
+
+      ! -----------------------------------------------------------
+      ! 2. Calculate Spatial Shifts (Yee Cell Staggering)
+      !    We use MERGE to apply the (i-1) shift only in the relevant direction.
+      ! -----------------------------------------------------------
+
+      ! Shift for Term A
+      i_shift_a = i - merge(1, 0, curl_component_b == iex)
+      j_shift_a = j - merge(1, 0, curl_component_b == iey)
+      k_shift_a = k - merge(1, 0, curl_component_b == iez)
+
+      ! Shift for Term B
+      i_shift_b = i - merge(1, 0, curl_component_a == iex)
+      j_shift_b = j - merge(1, 0, curl_component_a == iey)
+      k_shift_b = k - merge(1, 0, curl_component_a == iez)
+
+      ! -----------------------------------------------------------
+      ! 3. Calculate J (Curl Difference)
+      !    The H/M fields are accessed using an offset (+3) from the E-field index.
+      ! -----------------------------------------------------------
+
+      res = &
+         ! TERM B: (Negative term in the difference)
+         - (get_delta(curl_component_b, i, j, k, fields_reference)* &
+      ( get_field(curl_component_b + 3, i, j, k, fields_reference) - get_field(curl_component_b + 3, i_shift_b, j_shift_b, k_shift_b, fields_reference) ) &
+          ) + &
+         ! TERM A: (Positive term in the difference)
+         (get_delta(curl_component_a, i, j, k, fields_reference)* &
+      ( get_field(curl_component_a + 3, i, j, k, fields_reference) - get_field(curl_component_a + 3, i_shift_a, j_shift_a, k_shift_a, fields_reference) ) &
+          )
+
+   end function computej
+
+   function computeJ1(f, i, j, k, fields_reference) result(res)
+      implicit none
+      integer(kind=4), intent(in) :: f, i, j, k
+      type(fields_reference_t), intent(in) :: fields_reference
+      integer(kind=4) :: c       ! Complementary H-field index (Hy/Hz)
+      real(kind=rkind) :: res
+      real(kind=rkind) :: curl_h_term_a, curl_h_term_b, field_diff_term
+
+      ! Calculate complementary H-field index (e.g., if f=1 (Ex), c=5 (Hy) and c+1=6 (Hz) or vice versa depending on definitions)
+      ! For f=1 (Ex), c = mod(1-2, 3)+4 = mod(-1, 3)+4 = 2+4 = 6 (Hz).
+
+      c = mod(f - 2, 3) + 4 ! This typically corresponds to H_z for J_x, or H_x for J_y, etc.
+
+      ! First set of H-field terms
+      curl_h_term_a = get_delta(c, i, j, k, fields_reference)*get_field(c, i, j, k, fields_reference) + &
+                    get_delta(c, i+u(f,iHy), j+u(f,iHz), k+u(f,iHx), fields_reference) * get_field(c, i+u(f,iHy), j+u(f,iHz), k+u(f,iHx), fields_reference)
+
+      ! Second set of H-field terms
+    curl_h_term_b = get_delta(c, i, j, k, fields_reference) * get_field(c, i-u(f,iHx), j-u(f,iHy), k-u(f,iHz), fields_reference) + &
+                    get_delta(c, i+u(f,iHy), j+u(f,iHz), k+u(f,iHx), fields_reference) * get_field(c, i-u(f,iHx)+u(f,iHy), j-u(f,iHy)+u(f,iHz), k-u(f,iHz)+u(f,iHx), fields_reference)
+
+      ! E-field term (approximates the change in E-field at the J-node)
+      field_diff_term = get_delta(f, i, j, k, fields_reference)*( &
+                        get_field(f, i - u(f, iHy), j - u(f, iHz), k - u(f, iHx), fields_reference) - &
+                        get_field(f, i + u(f, iHy), j + u(f, iHz), k + u(f, iHx), fields_reference))
+
+      ! Final computation: J1 = - ((Curl_H_A) - (Curl_H_B) + (E_diff))
+      res = -((curl_h_term_a - curl_h_term_b) + field_diff_term)
+
+   end function computeJ1
+
+   function computeJ2(f, i, j, k, fields_reference) result(res)
+      implicit none
+      integer(kind=4), intent(in) :: f, i, j, k
+      type(fields_reference_t), intent(in) :: fields_reference
+      integer(kind=4) :: c       ! Complementary H-field index (Hx/Hy/Hz)
+      real(kind=rkind) :: res
+      real(kind=rkind) :: curl_h_term_a, curl_h_term_b, field_diff_term
+
+      ! Calculate complementary H-field index (e.g., if f=1 (Ex), c=4 (Hx) or c=5 (Hy))
+      ! For f=1 (Ex), c = mod(1-3, 3)+4 = mod(-2, 3)+4 = 1+4 = 5 (Hy). This is the second H-field curl component.
+      c = mod(f - 3, 3) + 4
+
+      ! First set of H-field terms
+      curl_h_term_a = get_delta(c, i, j, k, fields_reference)*get_field(c, i, j, k, fields_reference) + &
+                    get_delta(c, i+u(f,iHz), j+u(f,iHx), k+u(f,iHy), fields_reference) * get_field(c, i+u(f,iHz), j+u(f,iHx), k+u(f,iHy), fields_reference)
+
+      ! Second set of H-field terms
+    curl_h_term_b = get_delta(c, i, j, k, fields_reference) * get_field(c, i-u(f,iHx), j-u(f,iHy), k-u(f,iHz), fields_reference) + &
+                    get_delta(c, i+u(f,iHz), j+u(f,iHx), k+u(f,iHy), fields_reference) * get_field(c, i-u(f,iHx)+u(f,iHz), j-u(f,iHy)+u(f,iHx), k-u(f,iHz)+u(f,iHy), fields_reference)
+
+      ! E-field term (approximates the change in E-field at the J-node)
+      field_diff_term = get_delta(f, i, j, k, fields_reference)*( &
+                        get_field(f, i - u(f, iHz), j - u(f, iHx), k - u(f, iHy), fields_reference) - &
+                        get_field(f, i + u(f, iHz), j + u(f, iHx), k + u(f, iHy), fields_reference))
+
+      ! Final computation: J2 = (Curl_H_A) - (Curl_H_B) + (E_diff)
+      res = (curl_h_term_a - curl_h_term_b) + field_diff_term
+
+   end function computeJ2
+
+   integer function u(field1, field2)
+      integer(kind=4) :: field1, field2
+      if (field1 == field2) then
+         u = 1
+      else
+         u = 0
+      end if
+   end function
+
+   integer function currentType(field)
+      integer(kind=4) :: field
+      select case (field)
+      case (iEx); currentType = iJx
+      case (iEy); currentType = iJy
+      case (iEz); currentType = iJz
+      case (iHx); currentType = iBloqueJx
+      case (iHy); currentType = iBloqueJy
+      case (iHz); currentType = iBloqueJz
+      case default; call StopOnError(0, 0, 'field is not a E or H field')
+      end select
+   end function
+
+   function get_field(field, i, j, k, fields_reference) result(res)
+      implicit none
+      real(kind=rkind) :: res
+      integer(kind=4), intent(in) :: field, i, j, k
+      type(fields_reference_t), intent(in) :: fields_reference
+
+      ! Retrieves the field value based on the field index (1-3 for E, 4-6 for H)
+      select case (field)
+      case (iex); res = fields_reference%e%x(i, j, k)
+      case (iey); res = fields_reference%e%y(i, j, k)
+      case (iez); res = fields_reference%e%z(i, j, k)
+      case (ihx); res = fields_reference%h%x(i, j, k)
+      case (ihy); res = fields_reference%h%y(i, j, k)
+      case (ihz); res = fields_reference%h%z(i, j, k)
+      end select
+   end function get_field
+
+   function get_delta(field, i, j, k, fields_reference) result(res)
+      implicit none
+      real(kind=rkind) :: res
+      integer(kind=4), intent(in) :: field, i, j, k
+      type(fields_reference_t), intent(in) :: fields_reference
+
+      ! Retrieves the spatial step size (delta) corresponding to the field direction
+      ! Note: i, j, k are used to select the correct array index if the grid is non-uniform.
+      select case (field)
+      case (iex); res = fields_reference%e%deltax(i)
+      case (iey); res = fields_reference%e%deltay(j)
+      case (iez); res = fields_reference%e%deltaz(k)
+      case (ihx); res = fields_reference%h%deltax(i)
+      case (ihy); res = fields_reference%h%deltay(j)
+      case (ihz); res = fields_reference%h%deltaz(k)
+      end select
+   end function get_delta
+
+   subroutine create_data_file(filePathReference, probePathReference, domainTypeReference, fileExtension)
+      use directoryUtils_m
+      character(len=*), intent(out) :: filePathReference
+      character(len=*), intent(in) :: probePathReference
+      character(len=*), intent(in) :: domainTypeReference
+      character(len=*), intent(in) :: fileExtension
+
+      character(len=1) :: sep = '_'
+      integer :: err
+
+      filePathReference = trim(probePathReference)//sep//trim(domainTypeReference)//fileExtension
+      call create_file_with_path(filePathReference, err)
+   end subroutine
+
+end module outputUtils_m

--- a/src_output/volumicProbeUtils.F90
+++ b/src_output/volumicProbeUtils.F90
@@ -1,0 +1,367 @@
+module volumicProbeUtils_m
+   use FDETYPES_m
+   use utils_m
+   use outputTypes_m
+   use outputUtils_m
+   implicit none
+   private
+
+   ! Public interface
+   public :: find_and_store_important_coords
+   public :: isValidPointForCurrent
+   public :: isValidPointForField
+   public :: createUnstructuredDataForVTU
+
+   abstract interface
+      logical function logical_func(component, i, j, k, problemInfo)
+         import :: problem_info_t, SINGLE
+         type(problem_info_t), intent(in) :: problemInfo
+         integer(kind=SINGLE), intent(in) :: component, i, j, k
+      end function logical_func
+   end interface
+
+   interface registerNode
+      module procedure &
+         registerNodeByIndex, &
+         registerNodeByCoordinate
+   end interface
+
+contains
+
+   subroutine find_and_store_important_coords(lowerBound, upperBound, component, problemInfo, nPoints, coords)
+      type(cell_coordinate_t), intent(in)             :: lowerBound, upperBound
+      integer(kind=SINGLE), intent(in)                :: component
+      type(problem_info_t), intent(in)                :: problemInfo
+      integer(kind=SINGLE), intent(out)               :: nPoints
+      integer(kind=SINGLE), allocatable, intent(inout) :: coords(:, :)
+
+      call count_required_coords(lowerBound, upperBound, component, problemInfo, nPoints)
+      call alloc_and_init(coords, 3, nPoints, 0_SINGLE)
+      call store_required_coords(lowerBound, upperBound, component, problemInfo, coords)
+   end subroutine find_and_store_important_coords
+
+   subroutine count_required_coords(lowerBound, upperBound, requestComponent, problemInfo, count)
+      type(cell_coordinate_t), intent(in) :: lowerBound, upperBound
+      integer(kind=SINGLE), intent(in)    :: requestComponent
+      type(problem_info_t), intent(in)    :: problemInfo
+      integer(kind=SINGLE), intent(out)   :: count
+
+      integer :: i, j, k
+      procedure(logical_func), pointer :: checker => null()
+      integer :: component
+
+      call get_checker_and_component(requestComponent, checker, component)
+
+      count = 0
+      do k = lowerBound%z, upperBound%z
+      do j = lowerBound%y, upperBound%y
+      do i = lowerBound%x, upperBound%x
+         if (checker(component, i, j, k, problemInfo)) count = count + 1
+      end do
+      end do
+      end do
+   end subroutine count_required_coords
+
+   subroutine store_required_coords(lowerBound, upperBound, requestComponent, problemInfo, coords)
+      type(cell_coordinate_t), intent(in) :: lowerBound, upperBound
+      integer(kind=SINGLE), intent(in)    :: requestComponent
+      type(problem_info_t), intent(in)    :: problemInfo
+      integer(kind=SINGLE), intent(inout) :: coords(:, :)
+
+      integer :: i, j, k, count
+      procedure(logical_func), pointer :: checker => null()
+      integer :: component
+
+      call get_checker_and_component(requestComponent, checker, component)
+
+      count = 0
+      do k = lowerBound%z, upperBound%z
+      do j = lowerBound%y, upperBound%y
+      do i = lowerBound%x, upperBound%x
+         if (checker(component, i, j, k, problemInfo)) then
+            count = count + 1
+            coords(1, count) = i
+            coords(2, count) = j
+            coords(3, count) = k
+         end if
+      end do
+      end do
+      end do
+   end subroutine store_required_coords
+
+   subroutine createUnstructuredDataForVTU(counter, coords, currentType, Nodes, Edges, Quads, numNodes, numEdges, numQuads, usevtkindex, realXGrid, realYGrid, realZGrid)
+      integer, intent(in) :: counter
+      integer(kind=SINGLE), intent(in) :: coords(:, :), currentType(:)
+      logical, intent(in) :: usevtkindex
+      real(KIND=RKIND), pointer, dimension(:), intent(in) :: realXGrid, realYGrid, realZGrid
+
+      integer(kind=4), intent(out):: numNodes, numQuads, numEdges
+      real(kind=RKIND), allocatable, dimension(:, :), intent(out) :: Nodes
+      integer(kind=4), allocatable, dimension(:, :), intent(out) ::  Edges, Quads
+
+      if (counter == 0) return
+
+      call countElements(counter, currentType, numEdges, numQuads)
+
+      allocate (Edges(2, numEdges))
+      allocate (Quads(4, numQuads))
+      allocate (Nodes(3, 2*numEdges + 4*numQuads))
+
+      call registerElements(counter, coords, currentType, Nodes, Edges, Quads, usevtkindex, realXGrid, realYGrid, realZGrid)
+      return
+   end subroutine
+
+   subroutine registerNodeByIndex(nodes, nodeIdx, x, y, z)
+      real(kind=RKIND), dimension(:, :), intent(inout) :: nodes
+      integer(kind=SINGLE), intent(in) :: nodeIdx, x, y, z
+      !We need to avoid using idx 0
+      nodes(1, nodeIdx + 1) = x*1.0_RKIND
+      nodes(2, nodeIdx + 1) = y*1.0_RKIND
+      nodes(3, nodeIdx + 1) = z*1.0_RKIND
+   end subroutine
+
+   subroutine registerNodeByCoordinate(nodes, nodeIdx, x, y, z)
+      real(kind=RKIND), dimension(:, :), intent(inout) :: nodes
+      integer(kind=SINGLE), intent(in) :: nodeIdx
+      real(kind=RKIND), intent(in) :: x, y, z
+      !We need to avoid using idx 0
+      nodes(1, nodeIdx + 1) = x
+      nodes(2, nodeIdx + 1) = y
+      nodes(3, nodeIdx + 1) = z
+   end subroutine
+
+   subroutine registerEdge(edges, edgeIdx, startNodeIdx, endNodeIdx)
+      integer(kind=SINGLE), dimension(:, :), intent(inout) :: edges
+      integer(kind=SINGLE), intent(in) :: edgeIdx, startNodeIdx, endNodeIdx
+
+      edges(1, edgeIdx + 1) = startNodeIdx
+      edges(2, edgeIdx + 1) = endNodeIdx
+   end subroutine
+
+   subroutine registerQuad(quads, quadIdx, firstNodeIdx, secondNodeIdx, thirdNodeIdx, fourthNodeIdx)
+      integer(kind=SINGLE), dimension(:, :), intent(inout) :: quads
+      integer(kind=SINGLE), intent(in) :: quadIdx, firstNodeIdx, secondNodeIdx, thirdNodeIdx, fourthNodeIdx
+
+      quads(1, quadIdx + 1) = firstNodeIdx
+      quads(2, quadIdx + 1) = secondNodeIdx
+      quads(3, quadIdx + 1) = thirdNodeIdx
+      quads(4, quadIdx + 1) = fourthNodeIdx
+   end subroutine
+
+   subroutine countElements(counter, currentType, numEdges, numQuads)
+      integer, intent(in) :: counter
+      integer(kind=SINGLE), intent(in) :: currentType(:)
+      integer(kind=4), intent(out) :: numEdges, numQuads
+      integer :: i
+
+      numEdges = 0
+      numQuads = 0
+
+      do i = 1, counter
+         if ((currentType(i) == iJx) .or. (currentType(i) == iJy) .or. (currentType(i) == iJz)) numEdges = numEdges + 1
+    if ((currentType(i) == iBloqueJx) .or. (currentType(i) == iBloqueJy) .or. (currentType(i) == iBloqueJz)) numQuads = numQuads + 1
+      end do
+   end subroutine
+
+   subroutine registerElements(counter, coords, currentType, Nodes, Edges, Quads, usevtkindex, realXGrid, realYGrid, realZGrid)
+      integer, intent(in) :: counter
+      integer(kind=SINGLE), intent(in) :: coords(:, :), currentType(:)
+      real(kind=RKIND), intent(inout) :: Nodes(:, :)
+      integer(kind=4), intent(inout) :: Edges(:, :), Quads(:, :)
+      logical :: usevtkindex
+      real(KIND=RKIND), pointer, dimension(:), intent(in) :: realXGrid, realYGrid, realZGrid
+
+      integer :: nodeIdx, quadIdx, edgeIdx
+      integer :: xCoord, yCoord, zCoord
+      integer :: i
+
+      nodeIdx = -1
+      quadIdx = -1
+      edgeIdx = -1
+
+      do i = 1, counter
+         xCoord = coords(1, i)
+         yCoord = coords(2, i)
+         zCoord = coords(3, i)
+
+         select case (currentType(i))
+         case (iJx)
+            nodeIdx = nodeIdx + 2
+            if (usevtkindex) then
+               call registerNode(Nodes, nodeIdx - 1, xCoord    , yCoord, zCoord    )
+               call registerNode(Nodes, nodeIdx    , xCoord + 1, yCoord, zCoord    )
+            else
+               call registerNode(Nodes, nodeIdx - 1, realXGrid(xCoord)    , realYGrid(yCoord), realZGrid(zCoord)    )
+               call registerNode(Nodes, nodeIdx    , realXGrid(xCoord + 1), realYGrid(yCoord), realZGrid(zCoord)    )
+            endif
+            edgeIdx = edgeIdx + 1
+            call registerEdge(Edges, edgeIdx, nodeIdx - 1, nodeIdx)
+
+         case (iJy)
+            nodeIdx = nodeIdx + 2
+            if (usevtkindex) then
+               call registerNode(Nodes, nodeIdx - 1, xCoord    , yCoord    , zCoord    )
+               call registerNode(Nodes, nodeIdx    , xCoord    , yCoord + 1, zCoord    )
+            else
+               call registerNode(Nodes, nodeIdx - 1, realXGrid(xCoord)    , realYGrid(yCoord)    , realZGrid(zCoord)    )
+               call registerNode(Nodes, nodeIdx    , realXGrid(xCoord)    , realYGrid(yCoord + 1), realZGrid(zCoord)    )
+            endif
+            edgeIdx = edgeIdx + 1
+            call registerEdge(Edges, edgeIdx, nodeIdx - 1, nodeIdx)
+
+         case (iJz)
+            nodeIdx = nodeIdx + 2
+            if (usevtkindex) then
+               call registerNode(Nodes, nodeIdx - 1, xCoord, yCoord    , zCoord    )
+               call registerNode(Nodes, nodeIdx    , xCoord, yCoord    , zCoord + 1)
+            else
+               call registerNode(Nodes, nodeIdx - 1, realXGrid(xCoord)    , realYGrid(yCoord)    , realZGrid(zCoord)    )
+               call registerNode(Nodes, nodeIdx    , realXGrid(xCoord)    , realYGrid(yCoord)    , realZGrid(zCoord + 1))
+            endif
+            edgeIdx = edgeIdx + 1
+            call registerEdge(Edges, edgeIdx, nodeIdx - 1, nodeIdx)
+
+         case (iBloqueJx)
+            nodeIdx = nodeIdx + 4
+            if (usevtkindex) then
+               call registerNode(Nodes, nodeIdx - 3, xCoord, yCoord    , zCoord    )
+               call registerNode(Nodes, nodeIdx - 2, xCoord, yCoord + 1, zCoord    )
+               call registerNode(Nodes, nodeIdx - 1, xCoord, yCoord + 1, zCoord + 1)
+               call registerNode(Nodes, nodeIdx    , xCoord, yCoord    , zCoord + 1)
+            else
+               call registerNode(Nodes, nodeIdx - 3, realXGrid(xCoord), realYGrid(yCoord)    , realZGrid(zCoord)    )
+               call registerNode(Nodes, nodeIdx - 2, realXGrid(xCoord), realYGrid(yCoord + 1), realZGrid(zCoord)    )
+               call registerNode(Nodes, nodeIdx - 1, realXGrid(xCoord), realYGrid(yCoord + 1), realZGrid(zCoord + 1))
+               call registerNode(Nodes, nodeIdx    , realXGrid(xCoord), realYGrid(yCoord)    , realZGrid(zCoord + 1))
+            endif
+            quadIdx = quadIdx + 1
+            call registerQuad(Quads, quadIdx, nodeIdx - 3, nodeIdx - 2, nodeIdx - 1, nodeIdx)
+
+         case (iBloqueJy)
+            nodeIdx = nodeIdx + 4
+            if (usevtkindex) then
+               call registerNode(Nodes, nodeIdx - 3, xCoord    , yCoord, zCoord    )
+               call registerNode(Nodes, nodeIdx - 2, xCoord + 1, yCoord, zCoord    )
+               call registerNode(Nodes, nodeIdx - 1, xCoord + 1, yCoord, zCoord + 1)
+               call registerNode(Nodes, nodeIdx    , xCoord    , yCoord, zCoord + 1)
+            else
+               call registerNode(Nodes, nodeIdx - 3, realXGrid(xCoord)    , realYGrid(yCoord), realZGrid(zCoord)    )
+               call registerNode(Nodes, nodeIdx - 2, realXGrid(xCoord + 1), realYGrid(yCoord), realZGrid(zCoord)    )
+               call registerNode(Nodes, nodeIdx - 1, realXGrid(xCoord + 1), realYGrid(yCoord), realZGrid(zCoord + 1))
+               call registerNode(Nodes, nodeIdx    , realXGrid(xCoord)    , realYGrid(yCoord), realZGrid(zCoord + 1))
+            endif
+            quadIdx = quadIdx + 1
+            call registerQuad(Quads, quadIdx, nodeIdx - 3, nodeIdx - 2, nodeIdx - 1, nodeIdx)
+
+         case (iBloqueJz)
+            nodeIdx = nodeIdx + 4
+            if (usevtkindex) then
+               call registerNode(Nodes, nodeIdx - 3, xCoord    , yCoord    , zCoord)
+               call registerNode(Nodes, nodeIdx - 2, xCoord + 1, yCoord    , zCoord)
+               call registerNode(Nodes, nodeIdx - 1, xCoord + 1, yCoord + 1, zCoord)
+               call registerNode(Nodes, nodeIdx    , xCoord    , yCoord + 1, zCoord)
+            else
+               call registerNode(Nodes, nodeIdx - 3, realXGrid(xCoord)    , realYGrid(yCoord)    , realZGrid(zCoord))
+               call registerNode(Nodes, nodeIdx - 2, realXGrid(xCoord + 1), realYGrid(yCoord)    , realZGrid(zCoord))
+               call registerNode(Nodes, nodeIdx - 1, realXGrid(xCoord + 1), realYGrid(yCoord + 1), realZGrid(zCoord))
+               call registerNode(Nodes, nodeIdx    , realXGrid(xCoord)    , realYGrid(yCoord + 1), realZGrid(zCoord))
+            endif
+            quadIdx = quadIdx + 1
+            call registerQuad(Quads, quadIdx, nodeIdx - 3, nodeIdx - 2, nodeIdx - 1, nodeIdx)
+         end select
+      end do
+   end subroutine
+
+   subroutine get_checker_and_component(request, checker, component)
+      integer(kind=SINGLE), intent(in)              :: request
+      procedure(logical_func), pointer, intent(out) :: checker
+      integer(kind=SINGLE), intent(out)             :: component
+
+      select case (request)
+      case (iCur); checker => volumicCurrentRequest; component = iCur
+      case (iMEC); checker => volumicElectricRequest; component = iMEC
+      case (iMHC); checker => volumicMagneticRequest; component = iMHC
+      case (iCurx); checker => componentCurrentRequest; component = iEx
+      case (iExC); checker => componentFieldRequest; component = iEx
+      case (iHxC); checker => componentFieldRequest; component = iHx
+      case (iCurY); checker => componentCurrentRequest; component = iEy
+      case (iEyC); checker => componentFieldRequest; component = iEy
+      case (iHyC); checker => componentFieldRequest; component = iHy
+      case (iCurZ); checker => componentCurrentRequest; component = iEz
+      case (iEzC); checker => componentFieldRequest; component = iEz
+      case (iHzC); checker => componentFieldRequest; component = iHz
+      end select
+   end subroutine get_checker_and_component
+
+   !--------------------------------------------------------------------------
+   ! Logic Functions
+   !--------------------------------------------------------------------------
+
+   logical function isValidPointForCurrent(request, i, j, k, problemInfo)
+      integer(kind=SINGLE), intent(in) :: request, i, j, k
+      type(problem_info_t), intent(in) :: problemInfo
+      select case (request)
+      case (iCur)
+         isValidPointForCurrent = volumicCurrentRequest(request, i, j, k, problemInfo)
+      case (iEx, iEy, iEz)
+         isValidPointForCurrent = componentCurrentRequest(request, i, j, k, problemInfo)
+      case default
+         isValidPointForCurrent = .false.
+      end select
+   end function isValidPointForCurrent
+
+   logical function isValidPointForField(request, i, j, k, problemInfo)
+      integer(kind=SINGLE), intent(in) :: request, i, j, k
+      type(problem_info_t), intent(in) :: problemInfo
+      select case (request)
+      case (iMEC)
+         isValidPointForField = volumicElectricRequest(request, i, j, k, problemInfo)
+      case (iMHC)
+         isValidPointForField = volumicMagneticRequest(request, i, j, k, problemInfo)
+      case (iEx, iEy, iEz, iHx, iHy, iHz)
+         isValidPointForField = componentFieldRequest(request, i, j, k, problemInfo)
+      case default
+         isValidPointForField = .false.
+      end select
+   end function isValidPointForField
+
+   logical function volumicCurrentRequest(request, i, j, k, problemInfo)
+      integer(kind=SINGLE), intent(in) :: request, i, j, k
+      type(problem_info_t), intent(in) :: problemInfo
+      volumicCurrentRequest = componentCurrentRequest(iEx, i, j, k, problemInfo) .or. &
+                              componentCurrentRequest(iEy, i, j, k, problemInfo) .or. &
+                              componentCurrentRequest(iEz, i, j, k, problemInfo)
+   end function volumicCurrentRequest
+
+   logical function volumicElectricRequest(request, i, j, k, problemInfo)
+      integer(kind=SINGLE), intent(in) :: request, i, j, k
+      type(problem_info_t), intent(in) :: problemInfo
+      volumicElectricRequest = componentFieldRequest(iEx, i, j, k, problemInfo) .or. &
+                               componentFieldRequest(iEy, i, j, k, problemInfo) .or. &
+                               componentFieldRequest(iEz, i, j, k, problemInfo)
+   end function volumicElectricRequest
+
+   logical function volumicMagneticRequest(request, i, j, k, problemInfo)
+      integer(kind=SINGLE), intent(in) :: request, i, j, k
+      type(problem_info_t), intent(in) :: problemInfo
+      volumicMagneticRequest = componentFieldRequest(iHx, i, j, k, problemInfo) .or. &
+                               componentFieldRequest(iHy, i, j, k, problemInfo) .or. &
+                               componentFieldRequest(iHz, i, j, k, problemInfo)
+   end function volumicMagneticRequest
+
+   logical function componentCurrentRequest(fieldDir, i, j, k, problemInfo)
+      integer(kind=SINGLE), intent(in) :: fieldDir, i, j, k
+      type(problem_info_t), intent(in) :: problemInfo
+      componentCurrentRequest = isWithinBounds(fieldDir, i, j, k, problemInfo)
+      if (componentCurrentRequest) then
+         componentCurrentRequest = isPEC(fieldDir, i, j, k, problemInfo) .or. isThinWire(fieldDir, i, j, k, problemInfo)
+      end if
+   end function componentCurrentRequest
+
+   logical function componentFieldRequest(fieldDir, i, j, k, problemInfo)
+      integer(kind=SINGLE), intent(in) :: fieldDir, i, j, k
+      type(problem_info_t), intent(in) :: problemInfo
+      componentFieldRequest = isWithinBounds(fieldDir, i, j, k, problemInfo)
+   end function componentFieldRequest
+
+end module volumicProbeUtils_m

--- a/src_utils/CMakeLists.txt
+++ b/src_utils/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_library(fdtd-utils
+  "utils.F90"
+  "valueReplacer.F90"
+  "allocationUtils.F90"
+  "directoryUtils.F90"
+  "logUtils.F90"
+)
+target_link_libraries(fdtd-utils
+ semba-types
+)

--- a/src_utils/allocationUtils.F90
+++ b/src_utils/allocationUtils.F90
@@ -1,0 +1,136 @@
+module allocationUtils_m
+   use FDETYPES_m, only: RKIND, CKIND, SINGLE, RKIND_tiempo, IKINDMTAG, INTEGERSIZEOFMEDIAMATRICES
+   implicit none
+   private
+   public :: alloc_and_init
+
+   interface alloc_and_init
+      procedure alloc_and_init_int_1D
+      procedure alloc_and_init_int_2D
+      procedure alloc_and_init_int_3D
+      procedure alloc_and_init_real_1D
+      procedure alloc_and_init_real_2D
+      procedure alloc_and_init_real_3D
+      procedure alloc_and_init_complex_1D
+      procedure alloc_and_init_complex_2D
+      procedure alloc_and_init_complex_3D
+      procedure alloc_and_init_int_3D_tag
+      procedure alloc_and_init_int_3D_med
+#ifndef CompileWithReal8
+      procedure alloc_and_init_real_time_1D
+#endif
+   end interface
+contains
+#ifndef CompileWithReal8
+   subroutine alloc_and_init_real_time_1D(array, n1, initVal)
+      REAL(RKIND_tiempo), allocatable, intent(inout) :: array(:)
+      integer, intent(IN) :: n1
+      REAL(RKIND_tiempo), intent(IN) :: initVal
+
+      allocate (array(n1))
+      array = initVal
+   END subroutine alloc_and_init_real_time_1D
+#endif
+   subroutine alloc_and_init_int_1D(array, n1, initVal)
+      integer(SINGLE), allocatable, intent(inout) :: array(:)
+      integer, intent(IN) :: n1
+      integer(SINGLE), intent(IN) :: initVal
+
+      allocate (array(n1))
+      array = initVal
+   END subroutine alloc_and_init_int_1D
+
+   subroutine alloc_and_init_int_2D(array, n1, n2, initVal)
+      integer(SINGLE), allocatable, intent(inout) :: array(:, :)
+      integer, intent(IN) :: n1, n2
+      integer(SINGLE), intent(IN) :: initVal
+
+      allocate (array(n1, n2))
+      array = initVal
+   END subroutine alloc_and_init_int_2D
+
+   subroutine alloc_and_init_int_3D(array, n1, n2, n3, initVal)
+      integer(SINGLE), allocatable, intent(inout) :: array(:, :, :)
+      integer, intent(IN) :: n1, n2, n3
+      integer(SINGLE), intent(IN) :: initVal
+
+      allocate (array(n1, n2, n3))
+      array = initVal
+   END subroutine alloc_and_init_int_3D
+
+   ! Allocate array of kind=IKINDMTAG
+   subroutine alloc_and_init_int_3D_tag(array, n1_min, n1_max, n2_min, n2_max, n3_min, n3_max, initVal)
+      integer(kind=IKINDMTAG), allocatable, intent(inout) :: array(:, :, :)
+      integer, intent(in) :: n1_min, n1_max, n2_min, n2_max, n3_min, n3_max
+      integer(kind=IKINDMTAG), intent(in) :: initVal
+
+      if (allocated(array)) deallocate (array)
+      allocate (array(n1_min:n1_max, n2_min:n2_max, n3_min:n3_max))
+      array = initVal
+   end subroutine
+
+   ! Allocate array of kind=INTEGERSIZEOFMEDIAMATRICES
+   subroutine alloc_and_init_int_3D_med(array, n1_min, n1_max, n2_min, n2_max, n3_min, n3_max, initVal)
+      integer(kind=INTEGERSIZEOFMEDIAMATRICES), allocatable, intent(inout) :: array(:, :, :)
+      integer, intent(in) :: n1_min, n1_max, n2_min, n2_max, n3_min, n3_max
+      integer(kind=INTEGERSIZEOFMEDIAMATRICES), intent(in) :: initVal
+
+      if (allocated(array)) deallocate (array)
+      allocate (array(n1_min:n1_max, n2_min:n2_max, n3_min:n3_max))
+      array = initVal
+   end subroutine
+
+   subroutine alloc_and_init_real_1D(array, n1, initVal)
+      REAL(RKIND), allocatable, intent(inout) :: array(:)
+      integer, intent(IN) :: n1
+      REAL(RKIND), intent(IN) :: initVal
+
+      allocate (array(n1))
+      array = initVal
+   END subroutine alloc_and_init_real_1D
+
+   subroutine alloc_and_init_real_2D(array, n1, n2, initVal)
+      REAL(RKIND), allocatable, intent(inout) :: array(:, :)
+      integer, intent(IN) :: n1, n2
+      REAL(RKIND), intent(IN) :: initVal
+
+      allocate (array(n1, n2))
+      array = initVal
+   END subroutine alloc_and_init_real_2D
+
+   subroutine alloc_and_init_real_3D(array, n1, n2, n3, initVal)
+      REAL(RKIND), allocatable, intent(inout) :: array(:, :, :)
+      integer, intent(IN) :: n1, n2, n3
+      REAL(RKIND), intent(IN) :: initVal
+
+      allocate (array(n1, n2, n3))
+      array = initVal
+   END subroutine alloc_and_init_real_3D
+
+   subroutine alloc_and_init_complex_1D(array, n1, initVal)
+      COMPLEX(CKIND), allocatable, intent(inout) :: array(:)
+      integer, intent(IN) :: n1
+      COMPLEX(CKIND), intent(IN) :: initVal
+
+      allocate (array(n1))
+      array = initVal
+   END subroutine alloc_and_init_complex_1D
+
+   subroutine alloc_and_init_complex_2D(array, n1, n2, initVal)
+      COMPLEX(CKIND), allocatable, intent(inout) :: array(:, :)
+      integer, intent(IN) :: n1, n2
+      COMPLEX(CKIND), intent(IN) :: initVal
+
+      allocate (array(n1, n2))
+      array = initVal
+   END subroutine alloc_and_init_complex_2D
+
+   subroutine alloc_and_init_complex_3D(array, n1, n2, n3, initVal)
+      COMPLEX(CKIND), allocatable, intent(inout) :: array(:, :, :)
+      integer, intent(IN) :: n1, n2, n3
+      COMPLEX(CKIND), intent(IN) :: initVal
+
+      allocate (array(n1, n2, n3))
+      array = initVal
+   END subroutine alloc_and_init_complex_3D
+end module allocationUtils_m

--- a/src_utils/directoryUtils.F90
+++ b/src_utils/directoryUtils.F90
@@ -1,0 +1,276 @@
+module directoryUtils_m
+   use FDETYPES_m
+   implicit none
+   private
+
+   public :: add_extension
+   public :: create_folder
+   public :: remove_extension
+   public :: folder_exists
+   public :: join_path
+   public :: get_last_component
+   public :: remove_folder
+   public :: file_exists
+   public :: delete_file
+   public :: list_files
+   public :: create_file_with_path
+   public :: get_path_separator
+
+contains
+
+   !------------------------------------------------------------
+   ! Add an extension to a filename
+   !------------------------------------------------------------
+   function add_extension(filename, ext) result(fullname)
+       character(len=*), intent(in) :: filename, ext
+       character(len=:), allocatable :: fullname
+
+       fullname = trim(filename) // trim(ext)
+   end function add_extension
+
+   !------------------------------------------------------------
+   ! Check if a folder exists
+   !------------------------------------------------------------
+   function folder_exists(path) result(exists)
+      character(len=*), intent(in) :: path
+      logical :: exists
+      character(len=BUFSIZE) :: p
+
+      p = trim(path)
+      if (index(p, '\') > 0) then
+         p = trim(p)//"\"
+      else
+         p = trim(p)//"/"
+      end if
+#ifdef GNUCompiler
+      inquire (file=p, exist=exists)
+#else
+      inquire (directory=p, exist=exists)
+#endif
+   end function folder_exists
+
+   !------------------------------------------------------------
+   ! Remove the final extension from a filename
+   !------------------------------------------------------------
+   function remove_extension(filename) result(base)
+       character(len=*), intent(in) :: filename
+       character(len=BUFSIZE) :: base
+       integer :: last_dot, n, i
+
+       base = trim(filename)
+       n = len_trim(base)
+       last_dot = 0
+
+       do i = n, 1, -1
+           if (base(i:i) == '.') then
+               last_dot = i
+               exit
+           end if
+       end do
+
+       if (last_dot > 0) then
+           base = base(:last_dot-1)
+       end if
+   end function remove_extension
+
+   !------------------------------------------------------------
+   ! Join two path components into one (simplified)
+   !------------------------------------------------------------
+   function join_path(base, child) result(fullpath)
+      character(len=*), intent(in) :: base, child
+      character(len=:), allocatable :: fullpath
+      character(len=1) :: sep
+      integer :: n
+
+
+      sep = get_path_separator()
+
+
+      fullpath = trim(base)
+      n = len_trim(fullpath)
+
+
+      if (n > 0) then
+      if (fullpath(n:n) /= sep) fullpath = fullpath // sep
+      end if
+
+
+      fullpath = fullpath // trim(child)
+      end function join_path
+
+   !------------------------------------------------------------
+   ! Get the last component of a path (file or folder)
+   !------------------------------------------------------------
+   function get_last_component(path) result(component)
+      character(len=*), intent(in) :: path
+      character(len=BUFSIZE) :: component
+      integer :: last_slash, n
+
+      n = len_trim(path)
+      component = path(:n)
+
+      if (n > 0) then
+         if (component(n:n) == get_path_separator()) component = component(:n - 1)
+      end if
+
+      last_slash = scan(component, get_path_separator(),.TRUE.)
+
+      if (last_slash > 0) then
+         component = component(last_slash + 1:)
+      end if
+   end function get_last_component
+
+   !------------------------------------------------------------
+   ! Create a folder (portable)
+   !------------------------------------------------------------
+   subroutine create_folder(path, ios)
+      character(len=*), intent(in) :: path
+      integer, intent(out) :: ios
+
+      if (folder_exists(path)) then
+         ios = 0
+         return
+      end if
+
+#ifdef __WIN32__
+      call execute_command_line("mkdir """//trim(path)//"""", exitstat=ios)
+#else
+      call execute_command_line("mkdir -p "//trim(path), exitstat=ios)
+#endif
+   end subroutine create_folder
+
+   !------------------------------------------------------------
+   ! Remove a folder
+   !------------------------------------------------------------
+   subroutine remove_folder(path, ios)
+      character(len=*), intent(in) :: path
+      integer, intent(out) :: ios
+
+      if (.not. folder_exists(path)) then
+         ios = 0
+         return
+      end if
+
+#ifdef __WIN32__
+      call execute_command_line("rmdir /S /Q """//trim(path)//"""", exitstat=ios)
+#else
+      call execute_command_line("rm -rf "//trim(path), exitstat=ios)
+#endif
+
+   end subroutine remove_folder
+
+   !------------------------------------------------------------
+   ! Check if a file exists
+   !------------------------------------------------------------
+   function file_exists(path) result(exists)
+      character(len=*), intent(in) :: path
+      logical :: exists
+
+      inquire (file=trim(path), exist=exists)
+   end function file_exists
+
+   !------------------------------------------------------------
+   ! Delete a file
+   !------------------------------------------------------------
+   subroutine delete_file(path, ios)
+      character(len=*), intent(in) :: path
+      integer, intent(out) :: ios
+
+      if (.not. file_exists(path)) then
+         ios = 0
+         return
+      end if
+
+#ifdef __WIN32__
+      call execute_command_line("del /Q """//trim(path)//"""", exitstat=ios)
+#else
+      call execute_command_line("rm -f "//trim(path), exitstat=ios)
+#endif
+
+   end subroutine delete_file
+
+   !------------------------------------------------------------
+   ! List files in a folder (simple)
+   !------------------------------------------------------------
+   subroutine list_files(path, files, nfiles, ios)
+      character(len=*), intent(in) :: path
+      character(len=BUFSIZE), dimension(:), intent(out) :: files
+      integer, intent(out) :: nfiles
+      integer, intent(out) :: ios
+
+      character(len=BUFSIZE) :: cmd
+      character(len=BUFSIZE) :: line
+      integer :: i
+      integer :: unit
+
+      nfiles = 0
+      ios = 0
+
+      if (.not. folder_exists(path)) then
+         ios = 1
+         return
+      end if
+
+#ifdef __WIN32__
+      cmd = 'dir /B "'//trim(path)//'"'
+#else
+      cmd = 'ls -1 "'//trim(path)//'"'
+#endif
+
+      open (newunit=unit, file=cmd, action='read', status='old', iostat=ios)
+
+      if (ios /= 0) return
+
+      do
+         read (unit, '(A)', iostat=ios) line
+         if (ios /= 0) exit
+         i = i + 1
+         if (i > size(files)) then
+            ios = 2
+            exit
+         end if
+         files(i) = adjustl(trim(line))
+      end do
+
+      nfiles = i
+      close (unit)
+
+   end subroutine list_files
+
+   !------------------------------------------------------------
+   ! Create a file, creating its folder if needed
+   !------------------------------------------------------------
+   subroutine create_file_with_path(fullpath, ios)
+      character(len=*), intent(in) :: fullpath
+      integer, intent(out) :: ios
+      integer :: unit
+
+      character(len=BUFSIZE) :: folder
+      integer :: pos
+
+      ios = 0
+      ! Find last slash or backslash
+      pos = index(fullpath, get_path_separator())
+
+      if (pos > 0) then
+         folder = adjustl(fullpath(:pos - 1))
+         call create_folder(trim(folder), ios)
+         if (ios /= 0) return
+      end if
+      open (newunit=unit, file=trim(adjustl(fullpath)), status='replace', iostat=ios)
+      if (ios == 0) close (unit)
+
+   end subroutine create_file_with_path
+
+   function get_path_separator() result(sep)
+      character(len=1) :: sep
+
+#ifdef __WIN32__
+      sep = '\'
+#else
+      sep = '/'
+#endif
+
+   end function get_path_separator
+
+end module directoryUtils_m

--- a/src_utils/logUtils.F90
+++ b/src_utils/logUtils.F90
@@ -1,0 +1,90 @@
+module logUtils_m
+   implicit none
+
+contains
+   subroutine printMessage(layoutNumber, message)
+      implicit none
+      integer, intent(in) :: layoutnumber
+      character(len=*), intent(in) :: message
+      logical :: printea
+      printea = .true.
+
+      ! Print into console
+      if (printea) then
+         write (*, '(a)') trim(adjustl(message))
+      end if
+
+      ! Print into unitFile 11
+      if (layoutnumber == 0) then
+         write (11, '(a)') trim(adjustl(message))
+      end if
+   end subroutine printMessage
+
+   subroutine printMessageWithSeparator(layoutnumber, message)
+      implicit none
+      integer, intent(in) :: layoutnumber
+      character(len=*), intent(in) :: message
+      logical :: printea
+      character(len=50) :: SEPARADOR
+      SEPARADOR = repeat('_', 50)
+      printea = .true.
+
+      ! Print into console
+      if (printea) then
+         write (*, '(a)') SEPARADOR
+         write (*, '(a)') trim(adjustl(message))
+         write (*, '(a)') SEPARADOR
+      end if
+
+      ! Print into unitFile 11
+      if (layoutnumber == 0) then
+         write (11, '(a)') SEPARADOR
+         write (11, '(a)') trim(adjustl(message))
+         write (11, '(a)') SEPARADOR
+      end if
+
+   end subroutine printMessageWithSeparator
+
+   subroutine printMessageWithEndingSeparator(layoutNumber, message)
+      implicit none
+      integer, intent(in) :: layoutnumber
+      character(len=*), intent(in) :: message
+      logical :: printea
+      character(len=50) :: SEPARADOR
+      SEPARADOR = repeat('_', 50)
+      printea = .true.
+
+      ! Print into console
+      if (printea) then
+         write (*, '(a)') SEPARADOR
+         write (*, '(a)') trim(adjustl(message))
+         write (*, '(a)') SEPARADOR
+      end if
+
+      ! Print into unitFile 11
+      if (layoutnumber == 0) then
+         write (11, '(a)') SEPARADOR
+         write (11, '(a)') trim(adjustl(message))
+         write (11, '(a)') SEPARADOR
+      end if
+   end subroutine printMessageWithEndingSeparator
+
+   subroutine printSeparator(layoutnumber)
+      implicit none
+      integer, intent(in) :: layoutnumber
+      logical :: printea
+      character(len=50) :: SEPARADOR
+      SEPARADOR = repeat('_', 50)
+      printea = .true.
+
+      ! Print into console
+      if (printea) then
+         write (*, '(a)') SEPARADOR
+      end if
+
+      ! Print into unitFile 11
+      if (layoutnumber == 0) then
+         write (11, '(a)') SEPARADOR
+      end if
+   end subroutine printSeparator
+end module logUtils_m

--- a/src_utils/utils.F90
+++ b/src_utils/utils.F90
@@ -1,0 +1,9 @@
+module utils_m
+  use allocationUtils_m
+  use valueReplacer_m
+  use directoryUtils_m
+  implicit none
+
+contains
+
+end module utils_m

--- a/src_utils/valueReplacer.F90
+++ b/src_utils/valueReplacer.F90
@@ -1,0 +1,130 @@
+module valueReplacer_m
+  use FDETYPES_m, only: RKIND, CKIND, SINGLE, RKIND_tiempo
+  implicit none
+  private
+
+  public :: replace_value
+
+  interface replace_value
+     ! Scalars
+     module procedure replace_scalar_int
+     module procedure replace_scalar_real
+     module procedure replace_scalar_complex
+
+     ! 1D arrays
+     module procedure replace_1d_int
+     module procedure replace_1d_real
+     module procedure replace_1d_complex
+
+     ! 2D arrays
+     module procedure replace_2d_int
+     module procedure replace_2d_real
+     module procedure replace_2d_complex
+
+     ! 3D arrays
+     module procedure replace_3d_int
+     module procedure replace_3d_real
+     module procedure replace_3d_complex
+  end interface
+
+contains
+  !=====================
+  ! Scalar replacements
+  !=====================
+  subroutine replace_scalar_int(x, val)
+    integer(SINGLE), intent(inout) :: x
+    integer(SINGLE), intent(in) :: val
+    x = val
+  end subroutine
+
+  subroutine replace_scalar_real(x, val)
+    real(RKIND), intent(inout) :: x
+    real(RKIND), intent(in) :: val
+    x = val
+  end subroutine
+
+  subroutine replace_scalar_real_t(x, val)
+    real(RKIND_tiempo), intent(inout) :: x
+    real(RKIND_tiempo), intent(in) :: val
+    x = val
+  end subroutine
+
+  subroutine replace_scalar_complex(x, val)
+    complex(CKIND), intent(inout) :: x
+    complex(CKIND), intent(in) :: val
+    x = val
+  end subroutine
+
+  !=====================
+  ! 1D array replacements
+  !=====================
+  subroutine replace_1d_int(x, idx1, val)
+    integer(SINGLE), intent(inout) :: x(:)
+    integer(SINGLE), intent(in) :: idx1
+    integer(SINGLE), intent(in) :: val
+    x(idx1) = val
+  end subroutine
+
+  subroutine replace_1d_real(x, idx1, val)
+    real(RKIND), intent(inout) :: x(:)
+    integer(SINGLE), intent(in) :: idx1
+    real(RKIND), intent(in) :: val
+    x(idx1) = val
+  end subroutine
+
+  subroutine replace_1d_complex(x, idx1, val)
+    complex(CKIND), intent(inout) :: x(:)
+    integer(SINGLE), intent(in) :: idx1
+    complex(CKIND), intent(in) :: val
+    x(idx1) = val
+  end subroutine
+
+  !=====================
+  ! 2D array replacements
+  !=====================
+  subroutine replace_2d_int(x, idx1, idx2, val)
+    integer(SINGLE), intent(inout) :: x(:,:)
+    integer(SINGLE), intent(in) :: idx1, idx2
+    integer(SINGLE), intent(in) :: val
+    x(idx1, idx2) = val
+  end subroutine
+
+  subroutine replace_2d_real(x, idx1, idx2, val)
+    real(RKIND), intent(inout) :: x(:,:)
+    integer(SINGLE), intent(in) :: idx1, idx2
+    real(RKIND), intent(in) :: val
+    x(idx1, idx2) = val
+  end subroutine
+
+  subroutine replace_2d_complex(x, idx1, idx2, val)
+    complex(CKIND), intent(inout) :: x(:,:)
+    integer(SINGLE), intent(in) :: idx1, idx2
+    complex(CKIND), intent(in) :: val
+    x(idx1, idx2) = val
+  end subroutine
+
+  !=====================
+  ! 3D array replacements
+  !=====================
+  subroutine replace_3d_int(x, idx1, idx2, idx3, val)
+    integer(SINGLE), intent(inout) :: x(:,:,:)
+    integer(SINGLE), intent(in) :: idx1, idx2, idx3
+    integer(SINGLE), intent(in) :: val
+    x(idx1, idx2, idx3) = val
+  end subroutine
+
+  subroutine replace_3d_real(x, idx1, idx2, idx3, val)
+    real(RKIND), intent(inout) :: x(:,:,:)
+    integer(SINGLE), intent(in) :: idx1, idx2, idx3
+    real(RKIND), intent(in) :: val
+    x(idx1, idx2, idx3) = val
+  end subroutine
+
+  subroutine replace_3d_complex(x, idx1, idx2, idx3, val)
+    complex(CKIND), intent(inout) :: x(:,:,:)
+    integer(SINGLE), intent(in) :: idx1, idx2, idx3
+    complex(CKIND), intent(in) :: val
+    x(idx1, idx2, idx3) = val
+  end subroutine
+
+end module valueReplacer_m


### PR DESCRIPTION
## Summary

Introduces the shared foundation for the new observation output subsystem.

- Adds reusable allocation, directory, logging, and value-replacement utilities.
- Defines common observation output types, domains, and helper routines.
- Adds volumic-probe utility support.
- Extends test fixtures with assertion helpers, simulation setup utilities, and observation builders.

## Scope

This PR intentionally excludes:

- Individual probe implementations.
- VTK and XDMF output implementations.
- Output dispatch and solver integration.

Those are delivered by the following stacked PRs.

## Validation

Validated with the complete stacked output implementation:

```bash
cmake -S . -B build-observation-no-mtln \
  -DCMAKE_BUILD_TYPE=Release \
  -DSEMBA_FDTD_ENABLE_MTLN=OFF \
  -DSEMBA_FDTD_ENABLE_OUTPUT_MODULE=ON

cmake --build build-observation-no-mtln -j

./build-observation-no-mtln/bin/fdtd_tests \
  --gtest_filter='output*:vtkapi*:xdmfapi*'
Result: 29 output, VTK, and XDMF tests passed.
```
## Notes
The full MTLN build is currently blocked by an existing vendored ngspice C23 bool typedef error.
