### PR TITLE
Add conformal SGBC support and related tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,8 +260,9 @@ if(SEMBA_FDTD_MAIN_LIB)
 		"src_main_pub/timestepping.F90"
 	)
 	target_link_libraries(semba-main
-		semba-outputs 
-		${SMBJSON_LIBRARIES} 
+		semba-outputs
+		conformal
+		${SMBJSON_LIBRARIES}
 		${MTLN_LIBRARIES})
 endif()
 

--- a/doc/fdtdjson.md
+++ b/doc/fdtdjson.md
@@ -148,7 +148,7 @@ The `elements` entry contains an array of JSON objects, each of which represents
   + `node`, representing a point in space. Elements with this type include a `<coordinateIds>` entry which is an array of a single integer representing the `id` of a coordinate and which must exist in the within the `mesh` `coordinates` list.
   + `polyline`, representing an oriented collection of segments. It must contain a list `<coordinateIds>` with at least two coordinates.
   + `cell`, containing a list of one or more `<intervals>` defined following the [interval convention](#the-interval-convention).
-  + `conformal` represents a conformal PEC element which contains a list of `[intervals]` and a list of `<triangles>`. An axis-aligned line with integer endpoints, or a rectangular surface on an integer grid face, is treated as ordinary PEC geometry. A rectangular surface with integer in-plane bounds and a non-integer constant coordinate is tessellated into conformal patches. Points, diagonal/non-grid-aligned lines, mixed-sign surface spans, and surfaces with non-integer in-plane bounds are invalid. The cells occupied by intervals and triangles can not contain both.
+  + `conformal` represents a conformal PEC or multilayered-surface element which contains a list of `[intervals]` and a list of `<triangles>`. An axis-aligned line with integer endpoints, or a rectangular surface on an integer grid face, is treated as ordinary geometry. A rectangular surface with integer in-plane bounds and a non-integer constant coordinate is tessellated into conformal patches. Points, diagonal/non-grid-aligned lines, mixed-sign surface spans, and surfaces with non-integer in-plane bounds are invalid. The cells occupied by intervals and triangles can not contain both.
   It also must contain an entry `subtype`, which can be:
     + `surface`, the intervals and triangles will be treated as a surface, which can be open or closed.
     + `volume`, the intervals and triangles must define a closed surface with all normals pointing outwards.
@@ -318,7 +318,18 @@ For each layer:
 
 For `multilayeredSurface`, the material `[name]` is also used as the NFDE file identifier.
 
-Its `elementIds` must reference `cell` elements. All `intervals` modeling entities different to oriented surfaces are ignored.
+Its `elementIds` can reference `cell` elements or `conformal` elements with
+`subtype: "surface"`. All `intervals` modeling entities different to oriented
+surfaces are ignored. A conformal multilayered surface currently supports only
+non-dispersive layers and serial/OpenMP execution with Crank-Nicolson SGBC time
+advancement; MPI, restart/resume, and stochastic material deviations are
+rejected. Each affected magnetic face must be split into two subfaces by the
+triangulation.
+
+For conformal surfaces, layer order follows triangle winding: the first layer
+is on the side opposite the oriented normal and the last layer is on the side
+towards it. Reversing all triangle vertices therefore reverses an asymmetric
+stack.
 
 ```json
 {

--- a/src_conformal/CMakeLists.txt
+++ b/src_conformal/CMakeLists.txt
@@ -5,6 +5,7 @@ set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/mod)
 add_library(conformal
 	"cell_map.F90"
     "conformal.F90"
+    "conformal_sgbc.F90"
     "geometry.F90"
 )
 

--- a/src_conformal/conformal.F90
+++ b/src_conformal/conformal.F90
@@ -35,9 +35,10 @@ contains
       end do
    end function
 
-   subroutine buildConformalMedia(conformalRegs, volumes, surfaces)
+   subroutine buildConformalMedia(conformalRegs, volumes, surfaces, sgbc_surfaces)
       type(ConformalPECRegions_t), pointer, intent(in) :: conformalRegs
       type(ConformalMedia_t), allocatable, dimension(:), intent(inout) :: volumes, surfaces
+      type(ConformalMedia_t), allocatable, dimension(:), optional, intent(inout) :: sgbc_surfaces
       if (associated(conformalRegs%volumes)) then
          volumes = buildMedia(conformalRegs%volumes)
       else
@@ -47,6 +48,13 @@ contains
          surfaces = buildSurfaceMedia(conformalRegs%surfaces)
       else
          allocate(surfaces(0))
+      end if
+      if (present(sgbc_surfaces)) then
+         if (associated(conformalRegs%sgbc_surfaces)) then
+            sgbc_surfaces = buildSGBCSurfaceMedia(conformalRegs%sgbc_surfaces)
+         else
+            allocate(sgbc_surfaces(0))
+         end if
       end if
    end subroutine
 
@@ -62,6 +70,50 @@ contains
          res(i) = buildMediaFromElement(canonical_element)
       end do
    end function buildSurfaceMedia
+
+   function buildSGBCSurfaceMedia(elements) result(res)
+      type(ConformalPECElements_t), dimension(:), pointer, intent(in) :: elements
+      type(ConformalMedia_t), dimension(:), allocatable :: res
+      type(side_t), dimension(:), allocatable :: local_sides
+      real(kind=rkind), dimension(3) :: oriented_normal
+      integer :: i, j, k, side_index, split_direction
+
+      allocate(res(size(elements)))
+      do i = 1, size(elements)
+         ! SGBC layer ordering is defined by user winding, so unlike PEC closed
+         ! surfaces this path must not canonicalize triangle orientation.
+         res(i) = buildMediaFromElement(elements(i))
+         res(i)%is_sgbc = .true.
+         res(i)%sgbc_profile = elements(i)%sgbc_profile
+         block
+            type(cell_map_t) :: cell_map
+            call buildCellMap(cell_map, elements(i))
+            do j = 1, res(i)%n_faces_media
+               do k = 1, res(i)%face_media(j)%size
+                  split_direction = res(i)%face_media(j)%faces(k)%split_direction
+                  local_sides = cell_map%getSidesInCell(res(i)%face_media(j)%faces(k)%cell)
+                  oriented_normal = 0.0_RKIND
+                  do side_index = 1, size(local_sides)
+                     oriented_normal = oriented_normal+local_sides(side_index)%normal
+                  end do
+                  if (.not. res(i)%face_media(j)%faces(k)%is_two_sided .or. split_direction == 0 .or. &
+                      res(i)%face_media(j)%faces(k)%lower_fraction <= TOPOLOGY_TOLERANCE .or. &
+                      res(i)%face_media(j)%faces(k)%lower_fraction >= 1.0_RKIND-TOPOLOGY_TOLERANCE) then
+                     call WarnErrReport('Conformal SGBC geometry must split each affected magnetic face into two subfaces.', .true.)
+                     res(i)%face_media(j)%faces(k)%surface_normal_sign = 0
+                  else if (abs(oriented_normal(split_direction)) <= TOPOLOGY_TOLERANCE) then
+                     call WarnErrReport('Conformal SGBC triangle winding does not define an unambiguous layer direction.', .true.)
+                     res(i)%face_media(j)%faces(k)%surface_normal_sign = 0
+                  else if (oriented_normal(split_direction) > 0.0_RKIND) then
+                     res(i)%face_media(j)%faces(k)%surface_normal_sign = 1
+                  else
+                     res(i)%face_media(j)%faces(k)%surface_normal_sign = -1
+                  end if
+               end do
+            end do
+         end block
+      end do
+   end function buildSGBCSurfaceMedia
 
    subroutine validateConformalSurface(element, is_valid, message)
       type(ConformalPECElements_t), intent(in) :: element

--- a/src_conformal/conformal_sgbc.F90
+++ b/src_conformal/conformal_sgbc.F90
@@ -1,0 +1,263 @@
+module conformal_sgbc_m
+
+   use FDETYPES_m, only: RKIND, RKIND_tiempo, SGBCMaterialProfile_t, EPSILON_VACUUM, MU_VACUUM
+   use Report_m, only: WarnErrReport
+   implicit none
+   private
+
+   type, public :: conformal_sgbc_state_t
+      logical :: initialized = .false.
+      integer :: n = 0
+      real(kind=RKIND), allocatable :: e(:), e_old(:), h(:), rhs(:)
+      real(kind=RKIND), allocatable :: e_ga(:), e_gb(:), h_ga(:), h_gb(:)
+      real(kind=RKIND), allocatable :: lower_diag(:), diagonal(:), upper_diag(:)
+      real(kind=RKIND), allocatable :: rhs_coeff(:,:)
+      real(kind=RKIND), allocatable :: upper_prime(:), rhs_prime(:)
+   contains
+      procedure :: init => conformal_sgbc_init
+      procedure :: advance => conformal_sgbc_advance
+      procedure :: lower_e => conformal_sgbc_lower_e
+      procedure :: upper_e => conformal_sgbc_upper_e
+      procedure :: destroy => conformal_sgbc_destroy
+   end type conformal_sgbc_state_t
+
+contains
+
+   subroutine conformal_sgbc_init(this, profile, dt, lower_distance, upper_distance, maximum_frequency, resolution, depth, reverse_layers)
+      class(conformal_sgbc_state_t), intent(inout) :: this
+      type(SGBCMaterialProfile_t), intent(in) :: profile
+      real(kind=RKIND_tiempo), intent(in) :: dt
+      real(kind=RKIND), intent(in) :: lower_distance, upper_distance, maximum_frequency, resolution
+      integer, intent(in) :: depth
+      logical, intent(in) :: reverse_layers
+      integer, allocatable :: subdivisions(:)
+      real(kind=RKIND), allocatable :: e_ds(:), h_ds(:), e_xi(:), h_xi(:), e_sigma(:), h_sigma(:)
+      real(kind=RKIND), allocatable :: cell_eps(:), cell_sigma(:)
+      integer :: layer, source_layer, first, last, index
+      real(kind=RKIND) :: fine_step
+
+      call this%destroy()
+      if (profile%num_layers <= 0) then
+         call WarnErrReport('Cannot initialize a conformal SGBC with an empty material profile.', .true.)
+         return
+      end if
+      if (depth == 0 .and. profile%num_layers > 1) then
+         call WarnErrReport('Conformal SGBC depth 0 only supports a single material layer.', .true.)
+         return
+      end if
+
+      allocate(subdivisions(profile%num_layers))
+      do layer = 1, profile%num_layers
+         subdivisions(layer) = layer_subdivisions(profile, layer, maximum_frequency, resolution, depth)
+      end do
+      this%n = sum(subdivisions)+1
+      allocate(this%e(1:this%n), this%e_old(1:this%n), this%h(0:this%n), this%rhs(1:this%n))
+      allocate(this%e_ga(1:this%n), this%e_gb(1:this%n), this%h_ga(0:this%n), this%h_gb(0:this%n))
+      allocate(this%lower_diag(1:this%n), this%diagonal(1:this%n), this%upper_diag(1:this%n))
+      allocate(this%rhs_coeff(3,1:this%n))
+      allocate(this%upper_prime(1:this%n), this%rhs_prime(1:this%n))
+      allocate(e_ds(1:this%n), h_ds(0:this%n), e_xi(1:this%n), h_xi(0:this%n), &
+               e_sigma(1:this%n), h_sigma(0:this%n))
+      allocate(cell_eps(0:this%n), cell_sigma(0:this%n))
+
+      h_ds = 0.0_RKIND
+      cell_eps = EPSILON_VACUUM
+      cell_sigma = 0.0_RKIND
+      h_xi = MU_VACUUM
+      h_sigma = 0.0_RKIND
+      last = 0
+      do layer = 1, profile%num_layers
+         if (reverse_layers) then
+            source_layer = profile%num_layers-layer+1
+         else
+            source_layer = layer
+         end if
+         first = last+1
+         last = first+subdivisions(source_layer)-1
+         fine_step = profile%thickness(source_layer)/real(subdivisions(source_layer), RKIND)
+         h_ds(first:last) = fine_step
+         cell_eps(first:last) = profile%eps(source_layer)
+         cell_sigma(first:last) = profile%sigma(source_layer)
+         h_xi(first:last) = profile%mu(source_layer)
+         h_sigma(first:last) = profile%sigmam(source_layer)
+      end do
+      h_ds(0) = lower_distance
+      h_ds(this%n) = upper_distance
+      h_xi(0) = MU_VACUUM
+      h_xi(this%n) = MU_VACUUM
+      h_sigma(0) = 0.0_RKIND
+      h_sigma(this%n) = 0.0_RKIND
+      do index = 1, this%n
+         ! Each E node spans half of the magnetic cell on either side.
+         ! The common factor one half cancels in this volume average.  This
+         ! handles vacuum/material boundaries and dissimilar layer interfaces
+         ! with the same expression.
+         e_xi(index) = (cell_eps(index-1)*h_ds(index-1)+cell_eps(index)*h_ds(index))/ &
+            (h_ds(index-1)+h_ds(index))
+         e_sigma(index) = (cell_sigma(index-1)*h_ds(index-1)+cell_sigma(index)*h_ds(index))/ &
+            (h_ds(index-1)+h_ds(index))
+         e_ds(index) = 0.5_RKIND*(h_ds(index-1)+h_ds(index))
+         this%e_ga(index) = advance_a(real(dt,RKIND), e_sigma(index), e_xi(index))
+         this%e_gb(index) = advance_b(real(dt,RKIND), e_sigma(index), e_xi(index), e_ds(index))
+      end do
+      this%h_ga(0) = 1.0_RKIND
+      this%h_ga(this%n) = 1.0_RKIND
+      this%h_gb(0) = 0.0_RKIND
+      this%h_gb(this%n) = 0.0_RKIND
+      do index = 1, this%n-1
+         this%h_ga(index) = advance_a(real(dt,RKIND), h_sigma(index), h_xi(index))
+         this%h_gb(index) = advance_b(real(dt,RKIND), h_sigma(index), h_xi(index), h_ds(index))
+      end do
+      call initialize_cn_coefficients(this)
+      this%e = 0.0_RKIND
+      this%e_old = 0.0_RKIND
+      this%h = 0.0_RKIND
+      this%rhs = 0.0_RKIND
+      this%initialized = .true.
+   end subroutine conformal_sgbc_init
+
+   integer function layer_subdivisions(profile, layer, maximum_frequency, resolution, depth) result(count)
+      type(SGBCMaterialProfile_t), intent(in) :: profile
+      integer, intent(in) :: layer, depth
+      real(kind=RKIND), intent(in) :: maximum_frequency, resolution
+      real(kind=RKIND) :: skin_depth, omega, argument
+
+      if (depth == 0) then
+         count = 1
+      else if (depth > 0) then
+         count = depth
+      else if (maximum_frequency <= 0.0_RKIND) then
+         count = 2
+      else
+         omega = 2.0_RKIND*acos(-1.0_RKIND)*maximum_frequency
+         argument = sqrt((omega*profile%eps(layer))**2 + profile%sigma(layer)**2)- &
+                    omega*profile%eps(layer)
+         if (argument <= tiny(1.0_RKIND)) then
+            skin_depth = huge(1.0_RKIND)
+         else
+            skin_depth = 1.0_RKIND/sqrt(0.5_RKIND*omega*profile%mu(layer)*argument)
+         end if
+         count = 1+int(resolution*profile%thickness(layer)/skin_depth)
+         count = max(2, count)
+      end if
+   end function layer_subdivisions
+
+   real(kind=RKIND) function advance_a(dt, sigma, xi) result(value)
+      real(kind=RKIND), intent(in) :: dt, sigma, xi
+      value = (2.0_RKIND*xi-dt*sigma)/(2.0_RKIND*xi+dt*sigma)
+      if (value < 0.0_RKIND) value = exp(-sigma*dt/xi)
+   end function advance_a
+
+   real(kind=RKIND) function advance_b(dt, sigma, xi, step) result(value)
+      real(kind=RKIND), intent(in) :: dt, sigma, xi, step
+      real(kind=RKIND) :: trapezoidal_a
+      trapezoidal_a = (2.0_RKIND*xi-dt*sigma)/(2.0_RKIND*xi+dt*sigma)
+      if (trapezoidal_a < 0.0_RKIND) then
+         value = (1.0_RKIND-exp(-sigma*dt/xi))/(sigma*step)
+      else
+         value = 2.0_RKIND*dt/(step*(2.0_RKIND*xi+dt*sigma))
+      end if
+   end function advance_b
+
+   subroutine initialize_cn_coefficients(this)
+      class(conformal_sgbc_state_t), intent(inout) :: this
+      integer :: index
+      this%lower_diag = 0.0_RKIND
+      this%upper_diag = 0.0_RKIND
+      do index = 2, this%n
+         this%lower_diag(index) = -0.25_RKIND*this%e_gb(index)*this%h_gb(index-1)
+      end do
+      do index = 1, this%n-1
+         this%upper_diag(index) = -0.25_RKIND*this%e_gb(index)*this%h_gb(index)
+      end do
+      do index = 1, this%n
+         this%diagonal(index) = 1.0_RKIND+0.25_RKIND*this%e_gb(index)* &
+            (this%h_gb(index-1)+this%h_gb(index))
+         this%rhs_coeff(1,index) = 0.5_RKIND*this%e_gb(index)*(1.0_RKIND+this%h_ga(index-1))
+         this%rhs_coeff(2,index) = 0.5_RKIND*this%e_gb(index)*(1.0_RKIND+this%h_ga(index))
+         this%rhs_coeff(3,index) = this%e_ga(index)-0.25_RKIND*this%e_gb(index)* &
+            (this%h_gb(index-1)+this%h_gb(index))
+      end do
+      this%diagonal(1) = 1.0_RKIND+0.25_RKIND*this%e_gb(1)*this%h_gb(1)
+      this%rhs_coeff(1,1) = this%e_gb(1)
+      this%rhs_coeff(3,1) = this%e_ga(1)-0.25_RKIND*this%e_gb(1)*this%h_gb(1)
+      this%diagonal(this%n) = 1.0_RKIND+0.25_RKIND*this%e_gb(this%n)*this%h_gb(this%n-1)
+      this%rhs_coeff(2,this%n) = this%e_gb(this%n)
+      this%rhs_coeff(3,this%n) = this%e_ga(this%n)-0.25_RKIND*this%e_gb(this%n)*this%h_gb(this%n-1)
+   end subroutine initialize_cn_coefficients
+
+   subroutine conformal_sgbc_advance(this, lower_h, upper_h)
+      class(conformal_sgbc_state_t), intent(inout) :: this
+      real(kind=RKIND), intent(in) :: lower_h, upper_h
+      integer :: index
+      if (.not. this%initialized) return
+      this%h(0) = lower_h
+      this%h(this%n) = upper_h
+      do index = 1, this%n
+         this%rhs(index) = this%rhs_coeff(1,index)*this%h(index-1)- &
+            this%rhs_coeff(2,index)*this%h(index)+this%rhs_coeff(3,index)*this%e(index)
+         if (index > 1) this%rhs(index) = this%rhs(index)-this%lower_diag(index)*this%e(index-1)
+         if (index < this%n) this%rhs(index) = this%rhs(index)-this%upper_diag(index)*this%e(index+1)
+      end do
+      this%e_old = this%e
+      call solve_tridiagonal(this%lower_diag, this%diagonal, this%upper_diag, this%rhs, this%e, &
+         this%upper_prime, this%rhs_prime)
+      do index = 1, this%n-1
+         this%h(index) = this%h_ga(index)*this%h(index)+0.5_RKIND*this%h_gb(index)* &
+            (this%e(index)-this%e(index+1)+this%e_old(index)-this%e_old(index+1))
+      end do
+   end subroutine conformal_sgbc_advance
+
+   subroutine solve_tridiagonal(lower, diagonal, upper, rhs, solution, upper_prime, rhs_prime)
+      real(kind=RKIND), intent(in) :: lower(:), diagonal(:), upper(:), rhs(:)
+      real(kind=RKIND), intent(out) :: solution(:)
+      real(kind=RKIND), intent(inout) :: upper_prime(:), rhs_prime(:)
+      real(kind=RKIND) :: pivot
+      integer :: index, n
+      n = size(diagonal)
+      upper_prime(1) = upper(1)/diagonal(1)
+      rhs_prime(1) = rhs(1)/diagonal(1)
+      do index = 2, n
+         pivot = diagonal(index)-lower(index)*upper_prime(index-1)
+         upper_prime(index) = upper(index)/pivot
+         rhs_prime(index) = (rhs(index)-lower(index)*rhs_prime(index-1))/pivot
+      end do
+      solution(n) = rhs_prime(n)
+      do index = n-1, 1, -1
+         solution(index) = rhs_prime(index)-upper_prime(index)*solution(index+1)
+      end do
+   end subroutine solve_tridiagonal
+
+   real(kind=RKIND) function conformal_sgbc_lower_e(this) result(value)
+      class(conformal_sgbc_state_t), intent(in) :: this
+      value = 0.0_RKIND
+      if (this%initialized) value = this%e(1)
+   end function conformal_sgbc_lower_e
+
+   real(kind=RKIND) function conformal_sgbc_upper_e(this) result(value)
+      class(conformal_sgbc_state_t), intent(in) :: this
+      value = 0.0_RKIND
+      if (this%initialized) value = this%e(this%n)
+   end function conformal_sgbc_upper_e
+
+   subroutine conformal_sgbc_destroy(this)
+      class(conformal_sgbc_state_t), intent(inout) :: this
+      if (allocated(this%e)) deallocate(this%e)
+      if (allocated(this%e_old)) deallocate(this%e_old)
+      if (allocated(this%h)) deallocate(this%h)
+      if (allocated(this%rhs)) deallocate(this%rhs)
+      if (allocated(this%e_ga)) deallocate(this%e_ga)
+      if (allocated(this%e_gb)) deallocate(this%e_gb)
+      if (allocated(this%h_ga)) deallocate(this%h_ga)
+      if (allocated(this%h_gb)) deallocate(this%h_gb)
+      if (allocated(this%lower_diag)) deallocate(this%lower_diag)
+      if (allocated(this%diagonal)) deallocate(this%diagonal)
+      if (allocated(this%upper_diag)) deallocate(this%upper_diag)
+      if (allocated(this%rhs_coeff)) deallocate(this%rhs_coeff)
+      if (allocated(this%upper_prime)) deallocate(this%upper_prime)
+      if (allocated(this%rhs_prime)) deallocate(this%rhs_prime)
+      this%n = 0
+      this%initialized = .false.
+   end subroutine conformal_sgbc_destroy
+
+end module conformal_sgbc_m

--- a/src_json_parser/smbjson.F90
+++ b/src_json_parser/smbjson.F90
@@ -810,6 +810,19 @@ contains
          end do
       end do
 
+      ! A multilayered surface can contain both structured intervals and
+      ! conformal triangles. readLossyThinSurfaces handles the former; only the
+      ! triangle representation is appended here.
+      mAs = this%getMaterialAssociations([J_MAT_TYPE_MULTILAYERED_SURFACE])
+      do i = 1, size(mAs)
+         do j = 1, size(mAs(i)%elementIds)
+            cR = this%mesh%getConformalRegion(mAs(i)%elementIds(j), found)
+            if (.not. found .or. cR%type /= REGION_TYPE_SURFACE .or. size(cR%triangles) == 0) cycle
+            tagName = this%buildTagName(mAs(i)%materialId, mAs(i)%elementIds(j))
+            call appendSGBCRegion(res%sgbc_surfaces, cR, tagName, readSGBCProfile(mAs(i)%materialId))
+         end do
+      end do
+
    contains
       subroutine validateConformalMaterialAssociations()
          type(json_value), pointer :: allAssociations, association
@@ -827,13 +840,99 @@ contains
             do elementIndex = 1, size(materialAssociation%elementIds)
                element = this%elementTable%getId(materialAssociation%elementIds(elementIndex))
                if (this%getStrAt(element%p, J_TYPE, default='') /= J_ELEM_TYPE_CONFORMAL) cycle
-               if (this%getStrAt(material%p, J_TYPE) /= J_MAT_TYPE_PEC) then
-                  call WarnErrReport('Conformal elements can only be associated with PEC materials.', .true.)
+               if (this%getStrAt(material%p, J_TYPE) == J_MAT_TYPE_MULTILAYERED_SURFACE) then
+                  if (this%getStrAt(element%p, J_SUBTYPE, default='') /= J_CONF_SUBTYPE_SURFACE) then
+                     call WarnErrReport('Conformal multilayeredSurface materials require subtype surface.', .true.)
+                     return
+                  end if
+               else if (this%getStrAt(material%p, J_TYPE) /= J_MAT_TYPE_PEC) then
+                  call WarnErrReport('Conformal elements only support PEC or multilayeredSurface materials.', .true.)
                   return
                end if
             end do
          end do
       end subroutine
+
+      function readSGBCProfile(material_id) result(profile)
+         integer, intent(in) :: material_id
+         type(SGBCMaterialProfile_t) :: profile
+         type(json_value_ptr_t) :: material
+         type(json_value), pointer :: layers, layer
+         integer :: layer_index
+         logical :: has_value
+
+         material = this%matTable%getId(material_id)
+         profile%material_id = material_id
+         profile%name = trim(adjustl(this%getStrAt(material%p, J_NAME, default=' ')))
+         call this%core%get(material%p, J_MAT_MULTILAYERED_SURF_LAYERS, layers, found=has_value)
+         if (.not. has_value) then
+            call WarnErrReport('Conformal multilayeredSurface material has no layers.', .true.)
+            return
+         end if
+         profile%num_layers = this%core%count(layers)
+         if (profile%num_layers == 0) then
+            call WarnErrReport('Conformal multilayeredSurface material has an empty layer list.', .true.)
+            return
+         end if
+         allocate(profile%thickness(profile%num_layers), profile%eps(profile%num_layers), &
+                  profile%mu(profile%num_layers), profile%sigma(profile%num_layers), &
+                  profile%sigmam(profile%num_layers))
+         do layer_index = 1, profile%num_layers
+            call this%core%get_child(layers, layer_index, layer)
+            profile%sigma(layer_index) = this%getRealAt(layer, J_MAT_ELECTRIC_CONDUCTIVITY, default=0.0_RKIND)
+            profile%sigmam(layer_index) = this%getRealAt(layer, J_MAT_MAGNETIC_CONDUCTIVITY, default=0.0_RKIND)
+            profile%eps(layer_index) = this%getRealAt(layer, J_MAT_ABS_PERMITTIVITY, has_value)
+            if (.not. has_value) profile%eps(layer_index) = &
+               this%getRealAt(layer, J_MAT_REL_PERMITTIVITY, default=1.0_RKIND)*EPSILON_VACUUM
+            profile%mu(layer_index) = this%getRealAt(layer, J_MAT_ABS_PERMEABILITY, has_value)
+            if (.not. has_value) profile%mu(layer_index) = &
+               this%getRealAt(layer, J_MAT_REL_PERMEABILITY, default=1.0_RKIND)*MU_VACUUM
+            profile%thickness(layer_index) = &
+               this%getRealAt(layer, J_MAT_MULTILAYERED_SURF_THICKNESS, has_value)
+            if (.not. has_value) then
+               call WarnErrReport('Conformal multilayeredSurface layer is missing thickness.', .true.)
+               return
+            end if
+            if (profile%thickness(layer_index) <= 0.0_RKIND .or. &
+                profile%eps(layer_index) <= 0.0_RKIND .or. profile%mu(layer_index) <= 0.0_RKIND .or. &
+                profile%sigma(layer_index) < 0.0_RKIND .or. profile%sigmam(layer_index) < 0.0_RKIND) then
+               call WarnErrReport('Conformal multilayeredSurface layer contains invalid material values.', .true.)
+               return
+            end if
+         end do
+      end function readSGBCProfile
+
+      subroutine appendSGBCRegion(regions, region, tag_name, profile)
+         type(ConformalPECElements_t), dimension(:), pointer :: regions
+         type(conformal_region_t), intent(in) :: region
+         character(len=*), intent(in) :: tag_name
+         type(SGBCMaterialProfile_t), intent(in) :: profile
+         type(ConformalPECElements_t), dimension(:), allocatable :: enlarged
+         logical :: is_valid
+         character(len=256) :: validation_message
+         integer :: previous, index
+
+         previous = 0
+         if (associated(regions)) previous = size(regions)
+         allocate(enlarged(previous+1))
+         do index = 1, previous
+            enlarged(index) = regions(index)
+         end do
+         enlarged(previous+1)%triangles = region%triangles
+         ! Integer-grid intervals from the same element are owned by the
+         ! established structured SGBC path.  Keeping them here as well would
+         ! instantiate the sheet twice.
+         allocate(enlarged(previous+1)%intervals(0))
+         enlarged(previous+1)%tag = tag_name
+         enlarged(previous+1)%is_sgbc = .true.
+         enlarged(previous+1)%sgbc_profile = profile
+         if (associated(regions)) deallocate(regions)
+         allocate(regions(previous+1))
+         regions = enlarged
+         call validateConformalSurface(regions(previous+1), is_valid, validation_message)
+         if (.not. is_valid .and. .not. isFatalError()) &
+            call WarnErrReport('Invalid conformal SGBC surface '//trim(tag_name)//': '//trim(validation_message), .true.)
+      end subroutine appendSGBCRegion
 
       logical function isClosedRegion(region)
          type(conformal_region_t), intent(in) :: region

--- a/src_main_pub/calc_constants.F90
+++ b/src_main_pub/calc_constants.F90
@@ -32,7 +32,7 @@ module CALC_CONSTANTS_m
             g%gm1(r)=1.0_RKIND
             g%gm2(r)=0.0_RKIND
          else
-            if (sgg%Med(R)%Is%ConformalPEC) then
+            if (sgg%Med(R)%Is%ConformalPEC .or. sgg%Med(R)%Is%ConformalSGBC) then
                g%g1(r)  = 1 
                g%g2(r)  = sgg%dt /Epsilon
                g%gm1(r) = 1
@@ -209,4 +209,3 @@ end module CALC_CONSTANTS_m
 
 
    
-

--- a/src_main_pub/fdetypes.F90
+++ b/src_main_pub/fdetypes.F90
@@ -563,6 +563,7 @@ module  FDETYPES_m
       PML , &
       PEC , &
       ConformalPEC , &
+      ConformalSGBC , &
       PMC , &
       ThinWire , &
       Multiwire , &
@@ -620,6 +621,20 @@ module  FDETYPES_m
       integer(kind=4) :: size
    end type
 
+   ! Nominal, non-dispersive material profile used by both the JSON parser and
+   ! the conformal SGBC time-domain solver. Allocatable components make normal
+   ! derived-type assignment a deep copy.
+   type, public :: SGBCMaterialProfile_t
+      integer(kind=4) :: material_id = 0
+      integer(kind=4) :: num_layers = 0
+      character(len=BUFSIZE) :: name = ' '
+      real(kind=rkind), dimension(:), allocatable :: thickness
+      real(kind=rkind), dimension(:), allocatable :: eps
+      real(kind=rkind), dimension(:), allocatable :: mu
+      real(kind=rkind), dimension(:), allocatable :: sigma
+      real(kind=rkind), dimension(:), allocatable :: sigmam
+   end type SGBCMaterialProfile_t
+
    type, public :: edge_t
       integer(kind=4), dimension(3) :: cell
       integer(kind=4) :: direction = -1
@@ -635,6 +650,8 @@ module  FDETYPES_m
       logical :: is_two_sided = .false.
       integer(kind=4) :: split_direction = 0
       real(kind=rkind) :: lower_fraction = 0.0_RKIND
+      integer(kind=4) :: sgbc_profile_index = 0
+      integer(kind=4) :: surface_normal_sign = 0
       type(conformal_face_fields_t) :: region_I_fields, region_II_fields
    end type
 
@@ -653,6 +670,8 @@ module  FDETYPES_m
       type(conformal_edge_media_t), dimension(:), pointer :: edge_media => null()
       real(kind=rkind) :: time_step_scale_factor = 1.0
       character(len=BUFSIZE) :: tag
+      logical :: is_sgbc = .false.
+      type(SGBCMaterialProfile_t) :: sgbc_profile
    end type
 
 
@@ -703,6 +722,7 @@ module  FDETYPES_m
       type(Shared_t)                                        :: Hshared !hnormal info
       type(XYZlimit_t), dimension(1:6)                      :: Alloc,Sweep,SINPMLSweep
       type(MediaData_t), pointer, dimension( : )            :: Med
+      type(SGBCMaterialProfile_t), dimension(:), allocatable :: ConformalSGBCProfiles
       type(NodalSource_t), dimension( : ), pointer           :: NodalSource
       type(obses_t)  , pointer, dimension( : )              :: Observation
       !

--- a/src_main_pub/nfde_types.F90
+++ b/src_main_pub/nfde_types.F90
@@ -128,11 +128,14 @@ module NFDETypes_m
       type(triangle_t), dimension(:), allocatable :: triangles
       type(interval_t), dimension(:), allocatable :: intervals
       character(len=bufsize) :: tag
+      logical :: is_sgbc = .false.
+      type(SGBCMaterialProfile_t) :: sgbc_profile
    end type
 
    type, public :: ConformalPECRegions_t
       type(ConformalPECElements_t), dimension(:), pointer :: volumes => null()
       type(ConformalPECElements_t), dimension(:), pointer :: surfaces => null()
+      type(ConformalPECElements_t), dimension(:), pointer :: sgbc_surfaces => null()
    end type
 
    !------------------------------------------------------------------------------
@@ -803,5 +806,4 @@ contains
 
 
 end module NFDETypes_m
-
 

--- a/src_main_pub/preprocess_geom.F90
+++ b/src_main_pub/preprocess_geom.F90
@@ -103,9 +103,9 @@ contains
       & Alloc_iHz_XE, Alloc_iHz_YI, Alloc_iHz_YE, Alloc_iHz_ZI, Alloc_iHz_ZE
       !
       !
-      type(ConformalMedia_t), dimension(:), allocatable :: conformal_volumes, conformal_surfaces
-      real(kind=rkind), dimension(:), allocatable :: edge_ratios, face_ratios
-      type(side_tris_map_t), dimension(:), allocatable :: volume_side_maps, surface_side_maps
+      type(ConformalMedia_t), dimension(:), allocatable :: conformal_volumes, conformal_surfaces, conformal_sgbc_surfaces
+      real(kind=rkind), dimension(:), allocatable :: edge_ratios, face_ratios, sgbc_edge_ratios, sgbc_face_ratios
+      type(side_tris_map_t), dimension(:), allocatable :: volume_side_maps, surface_side_maps, sgbc_side_maps
       eps0=eps00; mu0=mu00; !chapuz para convertir la variables de paso en globales
       cluz=1.0_RKIND/sqrt(eps0*mu0)
       zvac=sqrt(mu0/eps0)
@@ -140,7 +140,7 @@ contains
      allocate(sgg%EShared%elem(1:sgg%EShared%MaxConta))
 
 
-      call buildConformalMedia(this%conformalRegs, conformal_volumes, conformal_surfaces)
+      call buildConformalMedia(this%conformalRegs, conformal_volumes, conformal_surfaces, conformal_sgbc_surfaces)
       sgg%dt = changeTimeStepIfConformalNeeded(sgg%dt)
       if (associated(this%conformalRegs%volumes)) then
          volume_side_maps = buildSideMaps(this%conformalRegs%volumes)
@@ -151,6 +151,11 @@ contains
          surface_side_maps = buildSideMaps(this%conformalRegs%surfaces)
       else
          allocate(surface_side_maps(0))
+      end if
+      if (associated(this%conformalRegs%sgbc_surfaces)) then
+         sgbc_side_maps = buildSideMaps(this%conformalRegs%sgbc_surfaces)
+      else
+         allocate(sgbc_side_maps(0))
       end if
 
 
@@ -207,6 +212,14 @@ contains
       contamedia = contamedia + ubound(edge_ratios,1) + ubound(face_ratios,1)
       if (findloc(edge_ratios, 0.0, 1) /= 0) contamedia = contamedia - 1
       if (findloc(face_ratios, 0.0, 1) /= 0) contamedia = contamedia - 1
+
+      call getDifferentEdgeRatios(sgbc_edge_ratios, conformal_sgbc_surfaces)
+      call getDifferentFaceRatios(sgbc_face_ratios, conformal_sgbc_surfaces)
+      if (ubound(conformal_sgbc_surfaces, 1) > 0) then
+         contamedia = contamedia + ubound(sgbc_edge_ratios,1) + ubound(sgbc_face_ratios,1)
+         if (findloc(sgbc_edge_ratios, 0.0, 1) /= 0) contamedia = contamedia - 1
+         if (findloc(sgbc_face_ratios, 0.0, 1) /= 0) contamedia = contamedia - 1
+      end if
 
 #ifdef CompileWithMTLN
       contamedia = contamedia + this%mtln%n_unsh
@@ -471,6 +484,7 @@ contains
       sgg%Med%Is%ThinSlot = .FALSE.
       sgg%Med%Is%PEC = .FALSE.
       sgg%Med%Is%ConformalPEC = .FALSE.
+      sgg%Med%Is%ConformalSGBC = .FALSE.
       sgg%Med%Is%PMC = .FALSE.
       sgg%Med%Is%PML = .FALSE.
       sgg%Med%Is%Volume = .FALSE.
@@ -2541,6 +2555,20 @@ contains
          contamedia = contamedia + ubound(edge_ratios,1) + ubound(face_ratios,1)
          if (findloc(edge_ratios, 0.0,1 ) /= 0) contamedia = contamedia - 1
          if (findloc(face_ratios, 0.0,1 ) /= 0) contamedia = contamedia - 1
+      end if
+
+      if (ubound(conformal_sgbc_surfaces, 1) > 0) then
+         allocate(sgg%ConformalSGBCProfiles(size(conformal_sgbc_surfaces)))
+         do j = 1, size(conformal_sgbc_surfaces)
+            sgg%ConformalSGBCProfiles(j) = conformal_sgbc_surfaces(j)%sgbc_profile
+            call addConformalMedia(sgg, media, conformal_sgbc_surfaces(j), sgbc_edge_ratios, &
+               sgbc_face_ratios, contamedia, conf_bounding_box, sgbc_side_maps(j), isSurface, .true., j)
+         end do
+         contamedia = contamedia + ubound(sgbc_edge_ratios,1) + ubound(sgbc_face_ratios,1)
+         if (findloc(sgbc_edge_ratios, 0.0,1 ) /= 0) contamedia = contamedia - 1
+         if (findloc(sgbc_face_ratios, 0.0,1 ) /= 0) contamedia = contamedia - 1
+      else
+         allocate(sgg%ConformalSGBCProfiles(0))
       end if
 
 #ifdef CompileWithMTLN
@@ -4821,8 +4849,8 @@ contains
       !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
       !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-      function computeConformalTimeFactor(volumes, surfaces) result(res)
-         type(ConformalMedia_t), dimension(:), allocatable, intent(in) :: volumes, surfaces
+      function computeConformalTimeFactor(volumes, surfaces, sgbc_surfaces) result(res)
+         type(ConformalMedia_t), dimension(:), allocatable, intent(in) :: volumes, surfaces, sgbc_surfaces
          real(kind=rkind) :: res
          integer :: i
          res = 1.0_RKIND
@@ -4832,12 +4860,15 @@ contains
          do i = 1, ubound(surfaces, 1)
             res = min(res, surfaces(i)%time_step_scale_factor)
          end do
+         do i = 1, ubound(sgbc_surfaces, 1)
+            res = min(res, sgbc_surfaces(i)%time_step_scale_factor)
+         end do
       end function computeConformalTimeFactor
 
       function changeTimeStepIfConformalNeeded(sgg_dt) result(res)
          real(kind=RKIND_tiempo), intent(in) :: sgg_dt
          real(kind=RKIND_tiempo) :: res, yee_dt, time_scale_factor
-         time_scale_factor = computeConformalTimeFactor(conformal_volumes, conformal_surfaces)
+         time_scale_factor = computeConformalTimeFactor(conformal_volumes, conformal_surfaces, conformal_sgbc_surfaces)
          yee_dt = (1.0_RKIND/(cluz*sqrt(((1.0_RKIND / minval(sgg%DX))**2.0_RKIND) + &
                   ((1.0_RKIND / minval(sgg%DY))**2.0_RKIND) + &
                   ((1.0_RKIND / minval(sgg%DZ))**2.0_RKIND))))
@@ -4930,7 +4961,8 @@ contains
          end do
       end subroutine getDifferentFaceRatios
 
-      subroutine addConformalMedia(sgg, media, conformal_media, edge_ratios, face_ratios, contamedia, bbox, side_map, type)
+      subroutine addConformalMedia(sgg, media, conformal_media, edge_ratios, face_ratios, contamedia, bbox, side_map, type, &
+                                   is_sgbc, profile_index)
          type(SGGFDTDINFO_t), intent(inout) :: sgg
          type(media_matrices_t), intent(inout) :: media
          type(ConformalMedia_t), intent(in) :: conformal_media
@@ -4941,7 +4973,15 @@ contains
          type(XYZlimit_t), intent(inout) :: bbox
          type(side_tris_map_t), intent(in) :: side_map
          integer(kind=4), intent(in) :: type
+         logical, optional, intent(in) :: is_sgbc
+         integer(kind=4), optional, intent(in) :: profile_index
          integer :: i, j
+         logical :: sgbc_behavior
+         integer(kind=4) :: sgbc_profile_index
+         sgbc_behavior = .false.
+         if (present(is_sgbc)) sgbc_behavior = is_sgbc
+         sgbc_profile_index = 0
+         if (present(profile_index)) sgbc_profile_index = profile_index
          call initConformalBoundingBox(sgg,bbox)
 
          if (findloc(edge_ratios, 0.0, 1) /= 0) then
@@ -4970,15 +5010,16 @@ contains
             face_ratios_no_zero = face_ratios
          end if
          num_media = contamedia
-         call addConformalEdgeMedia(sgg, media, conformal_media, num_media, edge_ratios_no_zero, bbox, type)
+         call addConformalEdgeMedia(sgg, media, conformal_media, num_media, edge_ratios_no_zero, bbox, type, sgbc_behavior)
          num_media = contamedia + ubound(edge_ratios_no_zero,1)
-         call addConformalFaceMedia(sgg, media, conformal_media, num_media, face_ratios_no_zero, bbox, type)
+         call addConformalFaceMedia(sgg, media, conformal_media, num_media, face_ratios_no_zero, bbox, type, &
+                                    sgbc_behavior, sgbc_profile_index)
          if (type == isVolume) then
             call addUndetectedBorderFaces(sgg, media, conformal_media, num_media, edge_ratios_no_zero, bbox, side_map)
          end if
       end subroutine
 
-      subroutine addConformalFaceMedia(sgg, media, conformal_media, num_media, face_ratios, bbox, type)
+      subroutine addConformalFaceMedia(sgg, media, conformal_media, num_media, face_ratios, bbox, type, is_sgbc, profile_index)
          type(SGGFDTDINFO_t), intent(INOUT) :: sgg
          type(media_matrices_t), intent(inout) :: media
          type(ConformalMedia_t), intent(in) :: conformal_media
@@ -4991,28 +5032,66 @@ contains
          type(face_t), dimension(:), allocatable :: combined_faces
          type(XYZlimit_t), intent(inout) :: bbox
          integer(kind=4), intent(in) :: type
-         integer :: j, k
+         logical, intent(in) :: is_sgbc
+         integer(kind=4), intent(in) :: profile_index
+         integer :: j, k, accepted_faces, next_face, existing_face_media
          do j = 1, conformal_media%n_faces_media
+            ! A zero-ratio group aliases medium zero in the legacy conformal
+            ! mapper.  It is an unsupported one-sided/grid-aligned SGBC case,
+            ! already reported by buildSGBCSurfaceMedia, and must never alter
+            ! the global PEC medium metadata.
+            if (is_sgbc .and. conformal_media%face_media(j)%ratio == 0.0_RKIND) cycle
             if (conformal_media%face_media(j)%ratio /= 0) then
                face_media = num_media + findloc(face_ratios, conformal_media%face_media(j)%ratio, 1)
-               sgg%Med(face_media)%Is%ConformalPEC = .TRUE.
+               sgg%Med(face_media)%Is%ConformalPEC = .not. is_sgbc
+               sgg%Med(face_media)%Is%ConformalSGBC = is_sgbc
                sgg%Med(face_media)%Is%Needed = .TRUE.
                if (type == isVolume) sgg%Med(face_media)%Is%Volume = .TRUE.
                if (type == isSurface) sgg%Med(face_media)%Is%Surface = .TRUE.
-               sgg%Med(face_media)%Priority = prior_PEC
+               if (is_sgbc) then
+                  sgg%Med(face_media)%Priority = prior_CS
+               else
+                  sgg%Med(face_media)%Priority = prior_PEC
+               end if
                sgg%Med(face_media)%Epr = this%mats%mats(1)%eps / Eps0
-               sgg%Med(face_media)%Sigma = 1.0e29_RKIND
+               if (is_sgbc) then
+                  sgg%Med(face_media)%Sigma = this%mats%mats(1)%sigma
+               else
+                  sgg%Med(face_media)%Sigma = 1.0e29_RKIND
+               end if
                sgg%Med(face_media)%Mur = conformal_media%face_media(j)%ratio * this%mats%mats(1)%mu / Mu0
-               sgg%Med(face_media)%SigmaM = 0.0_RKIND
+               sgg%Med(face_media)%SigmaM = this%mats%mats(1)%sigmam
             else
                face_media = 0
             end if
             previous_faces = 0
             if (allocated(sgg%Med(face_media)%ConformalFace)) previous_faces = ubound(sgg%Med(face_media)%ConformalFace, 1)
-            allocate(combined_faces(previous_faces + conformal_media%face_media(j)%size))
-            if (previous_faces > 0) combined_faces(1:previous_faces) = sgg%Med(face_media)%ConformalFace
+            accepted_faces = 0
             do k = 1, conformal_media%face_media(j)%size
                cell(:) = conformal_media%face_media(j)%faces(k)%cell(:)
+               select case(conformal_media%face_media(j)%faces(k)%direction)
+               case(F_X); existing_face_media = media%sggMiHx(cell(1), cell(2), cell(3))
+               case(F_Y); existing_face_media = media%sggMiHy(cell(1), cell(2), cell(3))
+               case(F_Z); existing_face_media = media%sggMiHz(cell(1), cell(2), cell(3))
+               end select
+               if (sgg%Med(existing_face_media)%Priority <= sgg%Med(face_media)%Priority) &
+                  accepted_faces = accepted_faces+1
+            end do
+            allocate(combined_faces(previous_faces + accepted_faces))
+            if (previous_faces > 0) combined_faces(1:previous_faces) = sgg%Med(face_media)%ConformalFace
+            next_face = previous_faces
+            do k = 1, conformal_media%face_media(j)%size
+               cell(:) = conformal_media%face_media(j)%faces(k)%cell(:)
+               select case(conformal_media%face_media(j)%faces(k)%direction)
+               case(F_X); existing_face_media = media%sggMiHx(cell(1), cell(2), cell(3))
+               case(F_Y); existing_face_media = media%sggMiHy(cell(1), cell(2), cell(3))
+               case(F_Z); existing_face_media = media%sggMiHz(cell(1), cell(2), cell(3))
+               end select
+               ! Preserve a previously mapped higher-priority medium.  In the
+               ! normal priority configuration this makes PEC win at a
+               ! PEC/SGBC junction and, importantly, avoids creating an SGBC
+               ! state that is not connected to the selected Yee face.
+               if (sgg%Med(existing_face_media)%Priority > sgg%Med(face_media)%Priority) cycle
                if (cell(1) < bbox%xi) bbox%xi = cell(1)
                if (cell(1) > bbox%xe) bbox%xe = cell(1)
                if (cell(2) < bbox%yi) bbox%yi = cell(2)
@@ -5028,7 +5107,9 @@ contains
                case(F_Z)
                   media%sggMiHz(cell(1), cell(2), cell(3)) = face_media
                end select
-               combined_faces(previous_faces + k) = conformal_media%face_media(j)%faces(k)
+               next_face = next_face+1
+               combined_faces(next_face) = conformal_media%face_media(j)%faces(k)
+               if (is_sgbc) combined_faces(next_face)%sgbc_profile_index = profile_index
             end do
             call move_alloc(combined_faces, sgg%Med(face_media)%ConformalFace)
          end do
@@ -5047,7 +5128,7 @@ contains
          res = res/ubound(triangles,1)
       end function
 
-      subroutine addConformalEdgeMedia(sgg, media, conformal_media, num_media, edge_ratios, bbox, type)
+      subroutine addConformalEdgeMedia(sgg, media, conformal_media, num_media, edge_ratios, bbox, type, is_sgbc)
          type(SGGFDTDINFO_t), intent(INOUT) :: sgg
          type(media_matrices_t), intent(inout) :: media
          type(ConformalMedia_t), intent(in) :: conformal_media
@@ -5060,21 +5141,37 @@ contains
          type(edge_t), dimension(:), allocatable :: combined_edges
          type(XYZlimit_t), intent(inout) :: bbox
          integer(kind=4), intent(in) :: type
+         logical, intent(in) :: is_sgbc
          integer :: j, k
          real, dimension(3) :: normal
+
+         ! SGBC sheets are penetrable and therefore do not own Yee electric
+         ! edges.  In particular, processing a zero retained-edge ratio here
+         ! would mutate medium zero (PEC), even though no SGBC edge mapping is
+         ! required by the coupled face formulation.
+         if (is_sgbc) return
 
          do j = 1, conformal_media%n_edges_media
             if (conformal_media%edge_media(j)%ratio /= 0) then
                edge_media = num_media + findloc(edge_ratios, conformal_media%edge_media(j)%ratio,1)
-               sgg%Med(edge_media)%Is%ConformalPEC = .TRUE.
+               sgg%Med(edge_media)%Is%ConformalPEC = .not. is_sgbc
+               sgg%Med(edge_media)%Is%ConformalSGBC = is_sgbc
                sgg%Med(edge_media)%Is%Needed = .TRUE.
                if (type == isVolume) sgg%Med(edge_media)%Is%Volume = .TRUE.
                if (type == isSurface) sgg%Med(edge_media)%Is%Surface = .TRUE.
-               sgg%Med(edge_media)%Priority = prior_PEC
+               if (is_sgbc) then
+                  sgg%Med(edge_media)%Priority = prior_CS
+               else
+                  sgg%Med(edge_media)%Priority = prior_PEC
+               end if
                sgg%Med(edge_media)%Epr = (this%mats%mats(1)%eps / conformal_media%edge_media(j)%ratio ) / Eps0
-               sgg%Med(edge_media)%Sigma = 1.0e29_RKIND
+               if (is_sgbc) then
+                  sgg%Med(edge_media)%Sigma = this%mats%mats(1)%sigma
+               else
+                  sgg%Med(edge_media)%Sigma = 1.0e29_RKIND
+               end if
                sgg%Med(edge_media)%Mur = this%mats%mats(1)%mu / Mu0
-               sgg%Med(edge_media)%SigmaM = 0.0_RKIND
+               sgg%Med(edge_media)%SigmaM = this%mats%mats(1)%sigmam
             else
                edge_media = 0
             end if

--- a/src_main_pub/timestepping.F90
+++ b/src_main_pub/timestepping.F90
@@ -69,6 +69,7 @@ module Solver_m
 
    use EpsMuTimeScale_m
    use CALC_CONSTANTS_m
+   use conformal_sgbc_m, only: conformal_sgbc_state_t
 #ifdef CompileWithPrescale
    use P_rescale
 #endif              
@@ -89,6 +90,9 @@ module Solver_m
       real(kind=rkind) :: lower_fraction = 0.0_RKIND
       real(kind=rkind) :: lower_h = 0.0_RKIND
       real(kind=rkind) :: upper_h = 0.0_RKIND
+      logical :: is_sgbc = .false.
+      integer(kind=4) :: surface_normal_sign = 0
+      type(conformal_sgbc_state_t) :: sgbc
    end type conformal_surface_face_state_t
 
    type, public :: solver_t
@@ -2558,6 +2562,11 @@ contains
          end select
          call addConformalElectricCorrection(this, transverse_direction, i, j, k, &
                                               sign*inverse_step*lower_fraction*field_correction)
+         if (this%conformal_surface_faces(n)%is_sgbc) then
+            call this%conformal_surface_faces(n)%sgbc%advance( &
+               sign*this%conformal_surface_faces(n)%lower_h, &
+               sign*this%conformal_surface_faces(n)%upper_h)
+         end if
       end do
    end subroutine solver_advanceConformalE
 
@@ -2586,6 +2595,7 @@ contains
       real(kind=rkind) :: sign, split_inverse_step, transverse_inverse_step
       real(kind=rkind) :: lower_e, upper_e, transverse_lower_e, transverse_upper_e
       real(kind=rkind) :: lower_fraction, common_curl, magnetic_factor
+      real(kind=rkind) :: surface_lower_e, surface_upper_e
 
       if (.not. allocated(this%conformal_surface_faces)) return
       do n = 1, size(this%conformal_surface_faces)
@@ -2603,10 +2613,16 @@ contains
                                        transverse_lower_e, transverse_upper_e, transverse_inverse_step)
          common_curl = sign*(transverse_upper_e-transverse_lower_e)*transverse_inverse_step
          magnetic_factor = this%sgg%dt/this%mu0
+         surface_lower_e = 0.0_RKIND
+         surface_upper_e = 0.0_RKIND
+         if (this%conformal_surface_faces(n)%is_sgbc) then
+            surface_lower_e = this%conformal_surface_faces(n)%sgbc%lower_e()
+            surface_upper_e = this%conformal_surface_faces(n)%sgbc%upper_e()
+         end if
          this%conformal_surface_faces(n)%lower_h = this%conformal_surface_faces(n)%lower_h + &
-            magnetic_factor*(common_curl+sign*lower_e*split_inverse_step/lower_fraction)
+            magnetic_factor*(common_curl+sign*(lower_e-surface_lower_e)*split_inverse_step/lower_fraction)
          this%conformal_surface_faces(n)%upper_h = this%conformal_surface_faces(n)%upper_h + &
-            magnetic_factor*(common_curl-sign*upper_e*split_inverse_step/(1.0_RKIND-lower_fraction))
+            magnetic_factor*(common_curl+sign*(surface_upper_e-upper_e)*split_inverse_step/(1.0_RKIND-lower_fraction))
          ! Preserve the full-face magnetic flux represented by the Yee field.
          ! The weighted subface updates reduce exactly to the ordinary Yee curl.
          select case (normal_direction)
@@ -2651,14 +2667,38 @@ contains
    subroutine initializeConformalSurfaceStates(this)
       class(solver_t) :: this
       type(conformal_surface_face_state_t), allocatable :: states(:), enlarged(:)
-      integer :: medium, feature, split_direction
+      integer :: medium, feature, split_direction, transverse_direction
       type(face_t) :: face
-      real(kind=rkind) :: lower_fraction
+      real(kind=rkind) :: lower_fraction, grid_step
+      logical :: medium_is_sgbc
+
+      if (allocated(this%sgg%ConformalSGBCProfiles)) then
+         if (size(this%sgg%ConformalSGBCProfiles) > 0) then
+            if (this%control%num_procs > 1) then
+               call WarnErrReport('Conformal SGBC is not supported with more than one MPI rank.', .true.)
+               return
+            end if
+            if (this%control%resume) then
+               call WarnErrReport('Restart/resume is not supported for conformal SGBC.', .true.)
+               return
+            end if
+            if (.not. this%control%sgbccrank) then
+               call WarnErrReport('Conformal SGBC requires Crank-Nicolson time advancement.', .true.)
+               return
+            end if
+            if (this%control%stochastic) then
+               call WarnErrReport('Stochastic material deviations are not supported for conformal SGBC.', .true.)
+               return
+            end if
+         end if
+      end if
 
       allocate(states(0))
       do medium = 1, this%sgg%NumMedia
-         if (.not. this%sgg%Med(medium)%Is%ConformalPEC .or. &
+         if (.not. (this%sgg%Med(medium)%Is%ConformalPEC .or. &
+             this%sgg%Med(medium)%Is%ConformalSGBC) .or. &
              .not. this%sgg%Med(medium)%Is%Surface) cycle
+         medium_is_sgbc = this%sgg%Med(medium)%Is%ConformalSGBC
          if (.not. allocated(this%sgg%Med(medium)%ConformalFace)) cycle
          do feature = 1, size(this%sgg%Med(medium)%ConformalFace)
             face = this%sgg%Med(medium)%ConformalFace(feature)
@@ -2673,6 +2713,31 @@ contains
             enlarged(size(enlarged))%face_direction = face%direction
             enlarged(size(enlarged))%split_direction = split_direction
             enlarged(size(enlarged))%lower_fraction = lower_fraction
+            enlarged(size(enlarged))%is_sgbc = medium_is_sgbc
+            enlarged(size(enlarged))%surface_normal_sign = face%surface_normal_sign
+            if (medium_is_sgbc) then
+               if (face%sgbc_profile_index < 1 .or. &
+                   face%sgbc_profile_index > size(this%sgg%ConformalSGBCProfiles) .or. &
+                   face%surface_normal_sign == 0) then
+                  call WarnErrReport('Conformal SGBC face has invalid material or winding metadata.', .true.)
+                  return
+               end if
+               transverse_direction = 6-face%direction-split_direction
+               if (transverse_direction < 1 .or. transverse_direction > 3) then
+                  call WarnErrReport('Conformal SGBC face has an invalid split topology.', .true.)
+                  return
+               end if
+               select case(split_direction)
+               case(1); grid_step = 1.0_RKIND/this%Idxe(face%cell(1))
+               case(2); grid_step = 1.0_RKIND/this%Idye(face%cell(2))
+               case(3); grid_step = 1.0_RKIND/this%Idze(face%cell(3))
+               end select
+               call enlarged(size(enlarged))%sgbc%init( &
+                  this%sgg%ConformalSGBCProfiles(face%sgbc_profile_index), this%sgg%dt, &
+                  lower_fraction*grid_step, (1.0_RKIND-lower_fraction)*grid_step, &
+                  this%control%sgbcFreq, this%control%sgbcresol, this%control%sgbcdepth, &
+                  face%surface_normal_sign < 0)
+            end if
             call move_alloc(enlarged, states)
          end do
       end do

--- a/test/conformal/CMakeLists.txt
+++ b/test/conformal/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library (conformal_test_fortran
     "test_geometry.F90"
     "test_cell_map.F90"
     "test_filling.F90"
+    "test_conformal_sgbc.F90"
     # "test_pec_volume.F90"
 )
 

--- a/test/conformal/conformal_tests.h
+++ b/test/conformal/conformal_tests.h
@@ -36,6 +36,10 @@ extern "C" int test_conformal_filling_closed_corner();
 extern "C" int test_conformal_filling_block_and_corner();
 extern "C" int test_conformal_pec_media();
 extern "C" int test_conformal_pec_corner();
+extern "C" int test_conformal_sgbc_zero_state();
+extern "C" int test_conformal_sgbc_layer_orientation();
+extern "C" int test_conformal_sgbc_geometry_winding();
+extern "C" int test_conformal_sgbc_rejects_unsplit_geometry();
 
 TEST(conformal, geometry_coord_position)   { EXPECT_EQ(0, test_geometry_coord_position()); }
 TEST(conformal, geometry_side_position)    { EXPECT_EQ(0, test_geometry_side_position()); }
@@ -71,6 +75,10 @@ TEST(conformal, conformal_filling_closed)                      { EXPECT_EQ(0, te
 TEST(conformal, conformal_edge_next_cell)                      { EXPECT_EQ(0, test_conformal_edge_next_cell()); }
 TEST(conformal, conformal_filling_closed_corner)               { EXPECT_EQ(0, test_conformal_filling_closed_corner()); }
 TEST(conformal, conformal_filling_block_and_corner)            { EXPECT_EQ(0, test_conformal_filling_block_and_corner()); }
+TEST(conformal, conformal_sgbc_zero_state)                     { EXPECT_EQ(0, test_conformal_sgbc_zero_state()); }
+TEST(conformal, conformal_sgbc_layer_orientation)              { EXPECT_EQ(0, test_conformal_sgbc_layer_orientation()); }
+TEST(conformal, conformal_sgbc_geometry_winding)               { EXPECT_EQ(0, test_conformal_sgbc_geometry_winding()); }
+TEST(conformal, conformal_sgbc_rejects_unsplit_geometry)       { EXPECT_EQ(0, test_conformal_sgbc_rejects_unsplit_geometry()); }
 
 // TEST(conformal, conformal_pec_corner)        { EXPECT_EQ(0, test_conformal_pec_corner()); }
 // TEST(conformal, conformal_pec_media)        { EXPECT_EQ(0, test_conformal_pec_media()); }

--- a/test/conformal/test_conformal_sgbc.F90
+++ b/test/conformal/test_conformal_sgbc.F90
@@ -1,0 +1,119 @@
+integer function test_conformal_sgbc_zero_state() bind(C) result(err)
+   use conformal_sgbc_m
+   use FDETYPES_m
+   implicit none
+   type(SGBCMaterialProfile_t) :: profile
+   type(conformal_sgbc_state_t) :: state
+
+   err = 0
+   call make_profile(profile, .false.)
+   call state%init(profile, 1.0e-12_RKIND_tiempo, 0.005_RKIND, 0.005_RKIND, &
+      1.0e9_RKIND, 1.0_RKIND, 2, .false.)
+   call state%advance(0.0_RKIND, 0.0_RKIND)
+   if (.not. state%initialized) err = err+1
+   if (maxval(abs(state%e)) /= 0.0_RKIND) err = err+1
+   if (maxval(abs(state%h)) /= 0.0_RKIND) err = err+1
+contains
+   subroutine make_profile(profile, asymmetric)
+      type(SGBCMaterialProfile_t), intent(out) :: profile
+      logical, intent(in) :: asymmetric
+      profile%num_layers = 1
+      allocate(profile%thickness(1), profile%eps(1), profile%mu(1), profile%sigma(1), profile%sigmam(1))
+      profile%thickness = 0.001_RKIND
+      profile%eps = EPSILON_VACUUM
+      profile%mu = MU_VACUUM
+      profile%sigma = 10.0_RKIND
+      profile%sigmam = 0.0_RKIND
+   end subroutine
+end function test_conformal_sgbc_zero_state
+
+integer function test_conformal_sgbc_layer_orientation() bind(C) result(err)
+   use conformal_sgbc_m
+   use FDETYPES_m
+   use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
+   implicit none
+   type(SGBCMaterialProfile_t) :: profile
+   type(conformal_sgbc_state_t) :: forward, reverse
+   integer :: iteration
+
+   err = 0
+   profile%num_layers = 2
+   allocate(profile%thickness(2), profile%eps(2), profile%mu(2), profile%sigma(2), profile%sigmam(2))
+   profile%thickness = [0.0005_RKIND, 0.0015_RKIND]
+   profile%eps = [2.0_RKIND*EPSILON_VACUUM, EPSILON_VACUUM]
+   profile%mu = MU_VACUUM
+   profile%sigma = [0.0_RKIND, 100.0_RKIND]
+   profile%sigmam = 0.0_RKIND
+   call forward%init(profile, 1.0e-12_RKIND_tiempo, 0.005_RKIND, 0.005_RKIND, &
+      1.0e9_RKIND, 1.0_RKIND, 2, .false.)
+   call reverse%init(profile, 1.0e-12_RKIND_tiempo, 0.005_RKIND, 0.005_RKIND, &
+      1.0e9_RKIND, 1.0_RKIND, 2, .true.)
+   do iteration = 1, 8
+      call forward%advance(1.0_RKIND, 0.0_RKIND)
+      call reverse%advance(1.0_RKIND, 0.0_RKIND)
+   end do
+   if (.not. all(ieee_is_finite(forward%e)) .or. .not. all(ieee_is_finite(reverse%e))) err = err+1
+   if (maxval(abs(forward%e-reverse%e)) <= 100.0_RKIND*epsilon(1.0_RKIND)) err = err+1
+end function test_conformal_sgbc_layer_orientation
+
+integer function test_conformal_sgbc_geometry_winding() bind(C) result(err)
+   use conformal_m, only: buildSGBCSurfaceMedia
+   use NFDETypes_m, only: ConformalPECElements_t, ConformalMedia_t
+   use conformal_types_m, only: coord_t, triangle_t
+   implicit none
+   type(ConformalPECElements_t), dimension(:), pointer :: elements
+   type(ConformalMedia_t), dimension(:), allocatable :: media
+   type(coord_t) :: c1, c2, c3
+
+   err = 0
+   c1 = coord_t(position=[0.75, 0.0, 0.0], id=1)
+   c2 = coord_t(position=[0.75, 0.0, 1.0], id=2)
+   c3 = coord_t(position=[0.75, 1.0, 0.0], id=3)
+   allocate(elements(1))
+   allocate(elements(1)%triangles(1), elements(1)%intervals(0))
+   elements(1)%triangles(1) = triangle_t(vertices=[c1, c2, c3])
+
+   media = buildSGBCSurfaceMedia(elements)
+   call check_faces(media(1), -1, err)
+
+   elements(1)%triangles(1) = triangle_t(vertices=[c1, c3, c2])
+   media = buildSGBCSurfaceMedia(elements)
+   call check_faces(media(1), 1, err)
+contains
+   subroutine check_faces(item, expected_sign, err)
+      type(ConformalMedia_t), intent(in) :: item
+      integer, intent(in) :: expected_sign
+      integer, intent(inout) :: err
+      integer :: group, face
+      if (.not. item%is_sgbc) err = err+1
+      do group = 1, item%n_faces_media
+         do face = 1, item%face_media(group)%size
+            if (.not. item%face_media(group)%faces(face)%is_two_sided) err = err+1
+            if (item%face_media(group)%faces(face)%surface_normal_sign /= expected_sign) err = err+1
+         end do
+      end do
+   end subroutine check_faces
+end function test_conformal_sgbc_geometry_winding
+
+integer function test_conformal_sgbc_rejects_unsplit_geometry() bind(C) result(err)
+   use conformal_m, only: buildSGBCSurfaceMedia
+   use NFDETypes_m, only: ConformalPECElements_t, ConformalMedia_t
+   use conformal_types_m, only: coord_t, triangle_t
+   use Report_m, only: isFatalError, resetFatalError
+   implicit none
+   type(ConformalPECElements_t), dimension(:), pointer :: elements
+   type(ConformalMedia_t), dimension(:), allocatable :: media
+   type(coord_t) :: c1, c2, c3
+
+   err = 0
+   call resetFatalError()
+   c1 = coord_t(position=[0.0, 0.0, 0.0], id=1)
+   c2 = coord_t(position=[0.0, 1.0, 0.0], id=2)
+   c3 = coord_t(position=[0.0, 0.0, 1.0], id=3)
+   allocate(elements(1))
+   allocate(elements(1)%triangles(1), elements(1)%intervals(0))
+   elements(1)%triangles(1) = triangle_t(vertices=[c1, c2, c3])
+   media = buildSGBCSurfaceMedia(elements)
+   if (.not. isFatalError()) err = err+1
+   call resetFatalError()
+end function test_conformal_sgbc_rejects_unsplit_geometry

--- a/test/pyWrapper/test_full_system.py
+++ b/test/pyWrapper/test_full_system.py
@@ -1729,6 +1729,202 @@ def test_conformal_surface_midcell_reflection(tmp_path, normal_axis, propagation
     assert np.max(np.abs(shadow)) <= 0.01*np.max(np.abs(incident))
 
 
+@pytest.mark.conformal
+@pytest.mark.sgbc
+@pytest.mark.planewave
+@pytest.mark.probes
+def test_conformal_surface_midcell_sgbc_matches_analytic_and_structured(tmp_path):
+    """Validate the mid-cell SGBC against a slab and the structured solver."""
+    fn = CASES_FOLDER + 'conformal_surface/conformal_surface_midcell.fdtd.json'
+    material = {
+        'id': 1,
+        'name': 'single layer conformal SGBC',
+        'type': 'multilayeredSurface',
+        'layers': [{
+            'thickness': 0.01,
+            'relativePermittivity': 1.0,
+            'relativePermeability': 1.0,
+            'electricConductivity': 1.0,
+            'magneticConductivity': 0.0,
+        }],
+    }
+
+    conformal_folder = tmp_path/'conformal'
+    conformal_folder.mkdir()
+    conformal = FDTD(fn, path_to_exe=SEMBA_EXE,
+                     run_in_folder=conformal_folder)
+    conformal['materials'][0] = material
+    conformal.run()
+
+    left = Probe(conformal.getSolvedProbeFilenames('left')[0])
+    right = Probe(conformal.getSolvedProbeFilenames('right')[0])
+    incident = left['incident'].to_numpy()
+    reflected = left['field'].to_numpy()-incident
+    transmitted = right['field'].to_numpy()
+
+    assert np.all(np.isfinite(reflected))
+    assert np.all(np.isfinite(transmitted))
+
+    time = right['time'].to_numpy()
+    frequencies = np.fft.rfftfreq(time.size, time[1]-time[0])
+    incident_spectrum = np.fft.rfft(right['incident'].to_numpy())
+    fdtd_s21 = np.fft.rfft(transmitted)/incident_spectrum
+    selected = ((frequencies >= 1.0e8) & (frequencies <= 1.5e9)
+                & (np.abs(incident_spectrum)
+                   > 0.03*np.max(np.abs(incident_spectrum))))
+
+    from skrf.frequency import Frequency
+    from skrf.media import Freespace
+    import scipy.constants
+
+    frequency = Frequency.from_f(frequencies[selected], unit='Hz')
+    air = Freespace(frequency)
+    conductive_material = Freespace(
+        frequency,
+        ep_r=1+1.0/(1j*frequency.w*scipy.constants.epsilon_0),
+    )
+    slab = air.thru() ** conductive_material.line(0.01, unit='m') ** air.thru()
+    fdtd_s21_db = 20*np.log10(np.abs(fdtd_s21[selected]))
+    analytic_s21_db = 20*np.log10(np.abs(slab.s[:, 0, 1]))
+    assert np.allclose(fdtd_s21_db, analytic_s21_db, atol=0.25)
+
+    structured_folder = tmp_path/'structured'
+    structured_folder.mkdir()
+    structured = FDTD(fn, path_to_exe=SEMBA_EXE,
+                      run_in_folder=structured_folder)
+    structured['materials'][0] = material
+    structured_surface = structured['mesh']['elements'][0]
+    structured_surface.clear()
+    structured_surface.update({
+        'id': 1,
+        'name': 'structured SGBC',
+        'type': 'cell',
+        'intervals': [[[8, 0, 0], [8, 2, 2]]],
+    })
+    structured.run()
+    structured_left = Probe(structured.getSolvedProbeFilenames('left')[0])
+    structured_right = Probe(structured.getSolvedProbeFilenames('right')[0])
+    structured_incident = structured_left['incident'].to_numpy()
+    structured_reflected = (structured_left['field'].to_numpy()
+                            - structured_incident)
+
+    conformal_r = np.linalg.norm(reflected)/np.linalg.norm(incident)
+    conformal_t = np.linalg.norm(transmitted)/np.linalg.norm(incident)
+    structured_r = (np.linalg.norm(structured_reflected)
+                    / np.linalg.norm(structured_incident))
+    structured_t = (np.linalg.norm(structured_right['field'].to_numpy())
+                    / np.linalg.norm(structured_incident))
+    assert np.isclose(conformal_r, structured_r, rtol=0.12)
+    assert np.isclose(conformal_t, structured_t, rtol=0.12)
+
+
+@pytest.mark.conformal
+@pytest.mark.sgbc
+@pytest.mark.planewave
+@pytest.mark.probes
+@pytest.mark.parametrize("normal_axis,propagation,reverse_winding", [
+    ('x', 1, False), ('x', -1, False), ('x', 1, True),
+    ('y', 1, False), ('z', 1, False),
+])
+def test_conformal_sgbc_axes_directions_and_winding(
+        tmp_path, normal_axis, propagation, reverse_winding):
+    """Exercise SGBC coupling signs for every axis and both sheet sides."""
+    fn = CASES_FOLDER + 'conformal_surface/conformal_surface_midcell.fdtd.json'
+    solver = FDTD(fn, path_to_exe=SEMBA_EXE, run_in_folder=tmp_path)
+    solver['materials'][0] = {
+        'id': 1,
+        'name': 'symmetric conformal SGBC',
+        'type': 'multilayeredSurface',
+        'layers': [{
+            'thickness': 0.01,
+            'relativePermittivity': 1.0,
+            'relativePermeability': 1.0,
+            'electricConductivity': 1.0,
+            'magneticConductivity': 0.0,
+        }],
+    }
+
+    permutations = {'x': (0, 1, 2), 'y': (1, 0, 2), 'z': (2, 1, 0)}
+    permutation = permutations[normal_axis]
+    if normal_axis != 'x':
+        grid = solver['mesh']['grid']
+        grid['numberOfCells'] = [grid['numberOfCells'][i]
+                                 for i in permutation]
+        for coordinate in solver['mesh']['coordinates']:
+            position = coordinate['relativePosition']
+            coordinate['relativePosition'] = [position[i] for i in permutation]
+        for element in solver['mesh']['elements']:
+            for interval in element.get('intervals', []):
+                interval[0] = [interval[0][i] for i in permutation]
+                interval[1] = [interval[1][i] for i in permutation]
+
+    solver['boundary'].clear()
+    for axis in ('x', 'y', 'z'):
+        boundary_type = 'mur' if axis == normal_axis else 'periodic'
+        solver['boundary'][axis+'Lower'] = {'type': boundary_type}
+        solver['boundary'][axis+'Upper'] = {'type': boundary_type}
+
+    if normal_axis == 'x':
+        solver['sources'][0]['direction'] = {
+            'theta': propagation*np.pi/2, 'phi': 0.0}
+        probe_direction = 'z'
+    elif normal_axis == 'y':
+        solver['sources'][0]['direction'] = {
+            'theta': np.pi/2, 'phi': propagation*np.pi/2}
+        probe_direction = 'z'
+    else:
+        solver['sources'][0]['direction'] = {
+            'theta': 0.0 if propagation > 0 else np.pi, 'phi': 0.0}
+        solver['sources'][0]['polarization'] = {'theta': np.pi/2, 'phi': 0.0}
+        probe_direction = 'x'
+    for probe in solver['probes']:
+        probe['directions'] = [probe_direction]
+
+    if reverse_winding:
+        triangles = solver['mesh']['elements'][0]['triangles']
+        solver['mesh']['elements'][0]['triangles'] = [
+            [triangle[0], triangle[2], triangle[1]] for triangle in triangles
+        ]
+
+    solver.run()
+    incident_name, shadow_name = ('left', 'right') if propagation > 0 else ('right', 'left')
+    incident_probe = Probe(solver.getSolvedProbeFilenames(incident_name)[0])
+    shadow_probe = Probe(solver.getSolvedProbeFilenames(shadow_name)[0])
+    incident = incident_probe['incident'].to_numpy()
+    reflected = incident_probe['field'].to_numpy()-incident
+    transmitted = shadow_probe['field'].to_numpy()
+    reflection = np.linalg.norm(reflected)/np.linalg.norm(incident)
+    transmission = np.linalg.norm(transmitted)/np.linalg.norm(incident)
+    assert 0.55 < reflection < 0.75
+    assert 0.25 < transmission < 0.45
+
+
+@pytest.mark.conformal
+@pytest.mark.sgbc
+@pytest.mark.planewave
+@pytest.mark.probes
+def test_conformal_sgbc_high_conductivity_approaches_pec(tmp_path):
+    fn = CASES_FOLDER + 'conformal_surface/conformal_surface_midcell.fdtd.json'
+    solver = FDTD(fn, path_to_exe=SEMBA_EXE, run_in_folder=tmp_path)
+    solver['materials'][0] = {
+        'id': 1,
+        'name': 'high-conductivity conformal SGBC',
+        'type': 'multilayeredSurface',
+        'layers': [{
+            'thickness': 0.01,
+            'electricConductivity': 100.0,
+        }],
+    }
+    solver.run()
+    left = Probe(solver.getSolvedProbeFilenames('left')[0])
+    right = Probe(solver.getSolvedProbeFilenames('right')[0])
+    incident = left['incident'].to_numpy()
+    reflection = np.linalg.norm(left['field'].to_numpy()-incident)/np.linalg.norm(incident)
+    transmission = np.linalg.norm(right['field'].to_numpy())/np.linalg.norm(incident)
+    assert reflection > 0.98
+    assert transmission < 0.01
+
+
 @no_mtln_skip
 @pytest.mark.conformal
 @pytest.mark.wires

--- a/test/smbjson/smbjson_tests.h
+++ b/test/smbjson/smbjson_tests.h
@@ -13,6 +13,7 @@ extern "C" int test_parser_ctor();
 extern "C" int test_parser_read_mesh();
 extern "C" int test_parser_read_conformal_volume();
 extern "C" int test_parser_reject_conformal_nonpec_material();
+extern "C" int test_parser_read_conformal_sgbc_material();
 
 extern "C" int test_read_planewave();
 extern "C" int test_read_planewave_empty_elementids();
@@ -52,6 +53,7 @@ TEST(smbjson, parser_ctor)               { EXPECT_EQ(0, test_parser_ctor()); }
 TEST(smbjson, parser_read_mesh)          { EXPECT_EQ(0, test_parser_read_mesh()); }
 TEST(smbjson, parser_read_conf_volume)   { EXPECT_EQ(0, test_parser_read_conformal_volume()); }
 TEST(smbjson, parser_reject_conformal_nonpec_material) { EXPECT_EQ(0, test_parser_reject_conformal_nonpec_material()); }
+TEST(smbjson, parser_read_conformal_sgbc_material) { EXPECT_EQ(0, test_parser_read_conformal_sgbc_material()); }
 TEST(smbjson, read_planewave)            { EXPECT_EQ(0, test_read_planewave()); }
 TEST(smbjson, read_planewave_empty_elementids) { EXPECT_EQ(0, test_read_planewave_empty_elementids()); }
 TEST(smbjson, read_dielectricslab)       { EXPECT_EQ(0, test_read_dielectricslab()); }

--- a/test/smbjson/test_parser.F90
+++ b/test/smbjson/test_parser.F90
@@ -151,3 +151,32 @@ integer function test_parser_reject_conformal_nonpec_material() bind(C) result(e
    if (.not. isFatalError()) err = err + 1
    call resetFatalError()
 end function
+
+integer function test_parser_read_conformal_sgbc_material() bind(C) result(err)
+   use smbjson_m
+   use smbjson_testingTools
+   use FDETYPES_m, only: EPSILON_VACUUM, MU_VACUUM, RKIND
+   use Report_m, only: resetFatalError
+   implicit none
+
+   type(parser_t) :: parser
+   type(Parseador_t) :: problem
+
+   err = 0
+   call resetFatalError()
+   parser = parser_t(PATH_TO_TEST_DATA//INPUT_EXAMPLES//'conformal_sgbc_material.fdtd.json')
+   problem = parser%readProblemDescription()
+   if (.not. associated(problem%conformalRegs%sgbc_surfaces)) then
+      err = err+1
+      return
+   end if
+   if (size(problem%conformalRegs%sgbc_surfaces) /= 1) err = err+1
+   if (problem%conformalRegs%sgbc_surfaces(1)%sgbc_profile%material_id /= 7) err = err+1
+   if (problem%conformalRegs%sgbc_surfaces(1)%sgbc_profile%num_layers /= 2) err = err+1
+   if (abs(problem%conformalRegs%sgbc_surfaces(1)%sgbc_profile%thickness(2)-0.002_RKIND) > 1e-7_RKIND) err = err+1
+   if (abs(problem%conformalRegs%sgbc_surfaces(1)%sgbc_profile%eps(1)-2.0_RKIND*EPSILON_VACUUM) > &
+       1e-5_RKIND*EPSILON_VACUUM) err = err+1
+   if (abs(problem%conformalRegs%sgbc_surfaces(1)%sgbc_profile%mu(2)-4.0_RKIND*MU_VACUUM) > &
+       1e-5_RKIND*MU_VACUUM) err = err+1
+   if (problem%lossyThinSurfs%length /= 0) err = err+1
+end function

--- a/testData/input_examples/conformal_sgbc_material.fdtd.json
+++ b/testData/input_examples/conformal_sgbc_material.fdtd.json
@@ -1,0 +1,31 @@
+{
+  "general": {"timeStep": 1e-12, "numberOfSteps": 1},
+  "mesh": {
+    "grid": {"numberOfCells": [2, 2, 2], "steps": {"x": [1.0], "y": [1.0], "z": [1.0]}},
+    "coordinates": [
+      {"id": 1, "relativePosition": [0.5, 0.0, 0.0]},
+      {"id": 2, "relativePosition": [0.5, 1.0, 0.0]},
+      {"id": 3, "relativePosition": [0.5, 0.0, 1.0]}
+    ],
+    "elements": [
+      {"id": 1, "type": "conformal", "subtype": "surface", "intervals": [], "triangles": [[1, 2, 3]]}
+    ]
+  },
+  "materials": [
+    {
+      "id": 7,
+      "name": "two layer panel",
+      "type": "multilayeredSurface",
+      "layers": [
+        {"thickness": 0.001, "relativePermittivity": 2.0, "electricConductivity": 3.0},
+        {"thickness": 0.002, "relativePermeability": 4.0, "magneticConductivity": 5.0}
+      ]
+    }
+  ],
+  "boundary": {
+    "xLower": {"type": "mur"}, "xUpper": {"type": "mur"},
+    "yLower": {"type": "mur"}, "yUpper": {"type": "mur"},
+    "zLower": {"type": "mur"}, "zUpper": {"type": "mur"}
+  },
+  "materialAssociations": [{"materialId": 7, "elementIds": [1]}]
+}


### PR DESCRIPTION
- Updated the Solver module to include conformal SGBC state handling.
- Introduced new types and variables for conformal SGBC in the timestepping module.
- Implemented logic for advancing conformal SGBC states during solver iterations.
- Added tests for conformal SGBC functionality, including zero state, layer orientation, geometry winding, and rejection of unsplit geometry.
- Enhanced JSON parser to read conformal SGBC materials and validate their properties.
- Created a sample JSON input file for testing conformal SGBC materials.
- Updated CMake and test files to include new tests and dependencies.